### PR TITLE
v1.11.2 — tolerate user-disabled helper entities (#22, #24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -756,6 +756,57 @@ async def _set_amperage(self, target_amperage: int):
 
 ## Version History
 
+### v1.11.2 (2026-05-26)
+**FIX: Tolerate user-disabled helper entities at startup (issue #22 — xion2000)**
+
+**Problem reported**:
+User `xion2000` disabled a handful of helper entities manually in Home Assistant (Night Smart Charge controls + daily SOC targets) because his use case — retired, no overnight tariff — did not need them. After a HA restart the integration failed to initialize with no actionable error. Re-enabling the entities fixed it. Reported in [issue #22](https://github.com/antbald/ha-ev-smart-charger/issues/22).
+
+**Root cause**:
+[__init__.py](custom_components/ev_smart_charger/__init__.py) Phase 1 waits on `runtime_data.registration_event`, which only fires when `registered_entity_count >= expected_entity_count` (58 or 51 depending on PV-only mode). User-disabled entities never call `async_added_to_hass` ([entity_base.py:51](custom_components/ev_smart_charger/entity_base.py:51)), so the counter never reaches the target, the 10 s `asyncio.wait_for` times out, and the setup raises `ConfigEntryNotReady` with the unhelpful message "Timed out while waiting for EV Smart Charger helper entities registration".
+
+**Fix**:
+New helper `_async_wait_for_helper_registration()` in [__init__.py](custom_components/ev_smart_charger/__init__.py) replaces the inline `try/except`. Behaviour:
+
+| Scenario | Outcome |
+|---|---|
+| All helpers register within 10 s | Setup proceeds normally. Any stale Repairs entry from a previous run is cleared. |
+| Timeout, but `registered + disabled_by(any) ≥ expected` | The user consciously disabled the missing helpers. Setup proceeds in **degraded mode** using state-helper defaults (already tolerant of `None`/`unknown`/`unavailable`), logs a `WARNING` listing the disabled keys, and surfaces a Home Assistant Repairs entry (`severity=WARNING`, `translation_key="disabled_helpers"`). |
+| Timeout, real shortfall | Logs an `ERROR` with the count of genuinely missing entities and raises `ConfigEntryNotReady` so HA retries setup later. |
+
+The disabled-entity count is read from `homeassistant.helpers.entity_registry` filtered by `config_entry_id == entry.entry_id` and `disabled_by is not None` (covers `USER`, `INTEGRATION`, `HASS`, `CONFIG_ENTRY` — HA skips `async_added_to_hass` for all of them).
+
+**Safety verification**:
+Spot-checked every reader of the critical kill switch `evsc_forza_ricarica` ([automation_coordinator.py:65](custom_components/ev_smart_charger/automation_coordinator.py:65), [automations.py:410](custom_components/ev_smart_charger/automations.py:410), [solar_surplus.py:420](custom_components/ev_smart_charger/solar_surplus.py:420)). All use `if self._forza_ricarica_entity:` or `state_helper.get_bool(..., default=False)` guards, so disabling the kill switch = "kill switch OFF" = neutral behaviour. Same defensive pattern across `_blocker_enabled`, `_night_charge_*`, and every other helper lookup — degraded mode is safe by construction.
+
+**User-visible Repairs notice**:
+A new Repairs entry surfaces under **Settings → Devices & services → EV Smart Charger** whenever the warning fires. Translation strings added in EN/IT/NL ([strings.json](custom_components/ev_smart_charger/strings.json), [translations/en.json](custom_components/ev_smart_charger/translations/en.json), [translations/it.json](custom_components/ev_smart_charger/translations/it.json), [translations/nl.json](custom_components/ev_smart_charger/translations/nl.json)) with placeholders for count, disabled keys (sorted, truncated to 8), and entry title. Includes a `learn_more_url` pointing at issue #22. The Repairs entry is automatically cleared on the next successful boot once the user re-enables the entities.
+
+**Test coverage**:
+[tests/test_integration_setup.py](tests/test_integration_setup.py) adds three tests:
+- `test_entity_key_from_unique_id_matches_evsc_pattern` — unit test for the unique_id → key extractor.
+- `test_entity_key_from_unique_id_rejects_foreign_unique_id` — rejects unique_ids from other integrations or other EVSC entries on the same registry.
+- `test_async_setup_entry_proceeds_with_user_disabled_helpers` — regression test that mirrors xion2000's scenario: 7 EVSC helpers disabled with `RegistryEntryDisabler.USER`, registration timeout fired, setup must return `True` and a Repairs entry must exist with `translation_key="disabled_helpers"` and the expected placeholders.
+
+The pre-existing `test_async_setup_entry_raises_not_ready_on_registration_timeout` still verifies the genuine shortfall path (no disabled entities + zero registered → `ConfigEntryNotReady`). Full suite goes from 116 → 119 passing on this branch (the unrelated 22 pre-existing failures on master are unchanged).
+
+**Files modified**:
+- [custom_components/ev_smart_charger/__init__.py](custom_components/ev_smart_charger/__init__.py): new constant `DISABLED_HELPERS_ISSUE_PREFIX`, new helpers `_entity_key_from_unique_id`, `_collect_disabled_helper_keys`, `_refresh_disabled_helpers_issue`, `_async_wait_for_helper_registration`; Phase 1 try/except replaced by a single call to the new helper.
+- [custom_components/ev_smart_charger/const.py](custom_components/ev_smart_charger/const.py): `VERSION = "1.11.2"`.
+- [custom_components/ev_smart_charger/manifest.json](custom_components/ev_smart_charger/manifest.json): `"version": "1.11.2"`.
+- [custom_components/ev_smart_charger/strings.json](custom_components/ev_smart_charger/strings.json), [translations/en.json](custom_components/ev_smart_charger/translations/en.json), [translations/it.json](custom_components/ev_smart_charger/translations/it.json), [translations/nl.json](custom_components/ev_smart_charger/translations/nl.json): new top-level `issues.disabled_helpers` block.
+- [tests/test_integration_setup.py](tests/test_integration_setup.py): three new tests + imports for `er`, `ir`, `_entity_key_from_unique_id`.
+
+**Backward compatibility**:
+Zero schema / entity / API changes. No new config flow steps, no new entities, no behaviour change for installations where every helper is enabled (the happy path returns from `_async_wait_for_helper_registration` exactly as before — only the failure branch is new).
+
+**Known limitation / follow-up**:
+Disabling helper entities to "remove features I don't use" is technically tolerated now but still not a supported configuration model. The proper fix is to extend the v1.7.0 PV-only mode pattern (`has_home_battery(config)` → skip helpers) to other feature groups — Night Smart Charge, daily SOC schedule, hybrid inverter mode — via opt-in toggles in the config flow. Tracked at [issue #24](https://github.com/antbald/ha-ev-smart-charger/issues/24), not blocked by this release.
+
+**Upgrade priority**: 🟢 RECOMMENDED — Existing users see no behavioural change. Users who disabled helpers (knowingly or not) will see the integration start instead of failing, with a clear Repairs notice explaining what is going on.
+
+---
+
 ### v1.11.1 (2026-05-26)
 **FIX: Dashboard responsive on large monitors (27"/32"/4K) + extracted design system reference**
 

--- a/custom_components/ev_smart_charger/__init__.py
+++ b/custom_components/ev_smart_charger/__init__.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: no cover - compatibility branch for older HA core
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_time_interval,
@@ -22,6 +23,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_CREATE_DASHBOARD,
     DEFAULT_CREATE_DASHBOARD,
+    DEFAULT_NAME,
     DOMAIN,
     FRONTEND_CARD_FILENAME,
     FRONTEND_URL_BASE,
@@ -82,6 +84,137 @@ async def _async_register_frontend(hass: HomeAssistant) -> None:
     )
 
 
+DISABLED_HELPERS_ISSUE_PREFIX = "disabled_helpers"
+
+
+def _entity_key_from_unique_id(unique_id: str, entry_id: str) -> str | None:
+    """Extract the logical helper key from an EVSC entity unique_id.
+
+    Format is ``{DOMAIN}_{entry_id}_{key}`` — see entity_base.py:31.
+    Returns None if the unique_id does not match the EVSC pattern (e.g. it
+    belongs to a different integration sharing the registry).
+    """
+    prefix = f"{DOMAIN}_{entry_id}_"
+    if not unique_id.startswith(prefix):
+        return None
+    return unique_id[len(prefix):]
+
+
+def _collect_disabled_helper_keys(hass: HomeAssistant, entry_id: str) -> list[str]:
+    """Return logical keys of EVSC helper entities disabled in the registry.
+
+    "Disabled" here means ``disabled_by is not None`` for any reason
+    (USER, INTEGRATION, HASS, CONFIG_ENTRY). Home Assistant skips
+    ``async_added_to_hass`` for all of these, so they all break the
+    registration barrier in the same way.
+    """
+    ent_reg = er.async_get(hass)
+    disabled_keys: list[str] = []
+    for entry in ent_reg.entities.values():
+        if entry.config_entry_id != entry_id:
+            continue
+        if entry.disabled_by is None:
+            continue
+        key = _entity_key_from_unique_id(entry.unique_id, entry_id)
+        if key is not None:
+            disabled_keys.append(key)
+    return disabled_keys
+
+
+@callback
+def _refresh_disabled_helpers_issue(
+    hass: HomeAssistant, entry: ConfigEntry, disabled_keys: list[str]
+) -> None:
+    """Create or clear the Repairs entry for user-disabled helper entities."""
+    issue_id = f"{DISABLED_HELPERS_ISSUE_PREFIX}_{entry.entry_id}"
+    if not disabled_keys:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+        return
+
+    preview_limit = 8
+    preview = ", ".join(sorted(disabled_keys)[:preview_limit])
+    if len(disabled_keys) > preview_limit:
+        preview = f"{preview}, …"
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="disabled_helpers",
+        translation_placeholders={
+            "count": str(len(disabled_keys)),
+            "entities": preview,
+            "entry_title": entry.title or DEFAULT_NAME,
+        },
+        learn_more_url=(
+            "https://github.com/antbald/ha-ev-smart-charger/issues/22"
+        ),
+    )
+
+
+async def _async_wait_for_helper_registration(
+    hass: HomeAssistant, entry: ConfigEntry, runtime_data: EVSCRuntimeData
+) -> None:
+    """Wait for helper entities to register; tolerate user-disabled ones.
+
+    Behaviour (v1.11.1 — issue #22):
+      * Normal case — all helpers register within the timeout → return.
+      * User disabled some helpers — they never call ``async_added_to_hass``,
+        so the barrier never fires by itself. Once the timeout elapses, count
+        ``disabled_by != None`` entities via the entity registry: if
+        ``registered + disabled >= expected`` the user consciously turned
+        them off, so log a warning, surface a Repairs issue, and proceed in
+        degraded mode.
+      * Genuinely missing helpers (programming error, platform failure) →
+        raise ``ConfigEntryNotReady`` so HA retries setup later.
+    """
+    try:
+        await asyncio.wait_for(runtime_data.registration_event.wait(), timeout=10)
+        # Clean state — drop any stale Repairs entry left from a previous run.
+        _refresh_disabled_helpers_issue(hass, entry, [])
+        return
+    except TimeoutError as err:
+        disabled_keys = _collect_disabled_helper_keys(hass, entry.entry_id)
+        registered = runtime_data.registered_entity_count
+        expected = runtime_data.expected_entity_count
+        accounted = registered + len(disabled_keys)
+
+        if accounted >= expected:
+            _LOGGER.warning(
+                "⚠️  %d helper entit%s disabled by the user (registered=%d, "
+                "disabled=%d, expected=%d) — proceeding in degraded mode. "
+                "Disabled: %s",
+                len(disabled_keys),
+                "y" if len(disabled_keys) == 1 else "ies",
+                registered,
+                len(disabled_keys),
+                expected,
+                ", ".join(sorted(disabled_keys)),
+            )
+            _refresh_disabled_helpers_issue(hass, entry, disabled_keys)
+            return
+
+        missing = expected - accounted
+        _LOGGER.error(
+            "❌ Helper registration barrier failed: registered=%d, "
+            "disabled=%d, expected=%d, truly missing=%d. "
+            "Disabled keys: %s",
+            registered,
+            len(disabled_keys),
+            expected,
+            missing,
+            ", ".join(sorted(disabled_keys)) or "(none)",
+        )
+        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        entry.runtime_data = None
+        raise ConfigEntryNotReady(
+            f"Timed out waiting for {missing} EV Smart Charger helper "
+            f"entit{'y' if missing == 1 else 'ies'} to register"
+        ) from err
+
+
 async def _async_cleanup_partial_setup(runtime_data: EVSCRuntimeData) -> None:
     """Clean up partially initialized runtime services after setup failures."""
     cleanup_order = [
@@ -137,15 +270,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _LOGGER.info(f"✅ Platforms registered: {', '.join(PLATFORMS)}")
 
-    # Wait for entity registration barrier
-    try:
-        await asyncio.wait_for(runtime_data.registration_event.wait(), timeout=10)
-    except TimeoutError as err:
-        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-        entry.runtime_data = None
-        raise ConfigEntryNotReady(
-            "Timed out while waiting for EV Smart Charger helper entities registration"
-        ) from err
+    # Wait for entity registration barrier. Tolerates helper entities the user
+    # has disabled in HA — see issue #22 (xion2000) and
+    # _async_wait_for_helper_registration() above.
+    await _async_wait_for_helper_registration(hass, entry, runtime_data)
 
     _LOGGER.info(
         "✅ %s helper entities registered",

--- a/custom_components/ev_smart_charger/const.py
+++ b/custom_components/ev_smart_charger/const.py
@@ -2,7 +2,7 @@
 
 # ========== INTEGRATION METADATA ==========
 DOMAIN = "ev_smart_charger"
-VERSION = "1.11.1"
+VERSION = "1.11.2"
 DEFAULT_NAME = "EV Smart Charger"
 FRONTEND_URL_BASE = "/api/ev_smart_charger/frontend"
 FRONTEND_CARD_FILENAME = "ev-smart-charger-dashboard.js"

--- a/custom_components/ev_smart_charger/manifest.json
+++ b/custom_components/ev_smart_charger/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ev_smart_charger",
   "name": "EV Smart Charger",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "documentation": "https://github.com/antbald/ha-ev-smart-charger",
   "issue_tracker": "https://github.com/antbald/ha-ev-smart-charger/issues",
   "codeowners": [

--- a/custom_components/ev_smart_charger/strings.json
+++ b/custom_components/ev_smart_charger/strings.json
@@ -262,6 +262,12 @@
       "invalid_domain": "Entity must belong to the `number` or `input_number` domain."
     }
   },
+  "issues": {
+    "disabled_helpers": {
+      "title": "EV Smart Charger helper entities disabled",
+      "description": "{count} helper entit(y/ies) created by **{entry_title}** are currently disabled in Home Assistant, so they could not register at startup. The integration started in degraded mode using safe defaults for those values.\n\nDisabled: `{entities}`\n\nIf this was intentional you can ignore this notice. Otherwise, re-enable them under **Settings → Devices & services → EV Smart Charger → Entities** and reload the integration. Disabling helper entities to remove features you don't use is not supported — open an issue if you'd like an opt-out flag instead."
+    }
+  },
   "entity": {
     "switch": {
       "evsc_forza_ricarica": { "name": "Force charge" },

--- a/custom_components/ev_smart_charger/translations/en.json
+++ b/custom_components/ev_smart_charger/translations/en.json
@@ -262,6 +262,12 @@
       "invalid_domain": "Entity must belong to the `number` or `input_number` domain."
     }
   },
+  "issues": {
+    "disabled_helpers": {
+      "title": "EV Smart Charger helper entities disabled",
+      "description": "{count} helper entit(y/ies) created by **{entry_title}** are currently disabled in Home Assistant, so they could not register at startup. The integration started in degraded mode using safe defaults for those values.\n\nDisabled: `{entities}`\n\nIf this was intentional you can ignore this notice. Otherwise, re-enable them under **Settings → Devices & services → EV Smart Charger → Entities** and reload the integration. Disabling helper entities to remove features you don't use is not supported — open an issue if you'd like an opt-out flag instead."
+    }
+  },
   "entity": {
     "switch": {
       "evsc_forza_ricarica": { "name": "Force charge" },

--- a/custom_components/ev_smart_charger/translations/it.json
+++ b/custom_components/ev_smart_charger/translations/it.json
@@ -262,6 +262,12 @@
       "invalid_domain": "L'entita deve appartenere al dominio `number` o `input_number`."
     }
   },
+  "issues": {
+    "disabled_helpers": {
+      "title": "Entita helper di EV Smart Charger disabilitate",
+      "description": "{count} entita helper create da **{entry_title}** sono attualmente disabilitate in Home Assistant, quindi non si sono registrate all'avvio. L'integrazione e partita in modalita degradata usando valori di default sicuri.\n\nDisabilitate: `{entities}`\n\nSe la disabilitazione e voluta puoi ignorare questo avviso. Altrimenti riabilitale da **Impostazioni → Dispositivi e servizi → EV Smart Charger → Entita** e ricarica l'integrazione. Disabilitare gli helper per rimuovere funzioni che non usi non e supportato — apri una issue se vuoi un'opzione dedicata."
+    }
+  },
   "entity": {
     "switch": {
       "evsc_forza_ricarica": { "name": "Forza ricarica" },

--- a/custom_components/ev_smart_charger/translations/nl.json
+++ b/custom_components/ev_smart_charger/translations/nl.json
@@ -262,6 +262,12 @@
       "invalid_domain": "De entiteit moet tot het domein `number` of `input_number` behoren."
     }
   },
+  "issues": {
+    "disabled_helpers": {
+      "title": "EV Smart Charger helper-entiteiten uitgeschakeld",
+      "description": "{count} helper-entiteit(en) aangemaakt door **{entry_title}** zijn momenteel uitgeschakeld in Home Assistant en konden zich daardoor niet registreren bij het opstarten. De integratie startte in gedegradeerde modus met veilige standaardwaarden voor die velden.\n\nUitgeschakeld: `{entities}`\n\nAls dit bewust was, kun je deze melding negeren. Schakel ze anders weer in via **Instellingen → Apparaten en services → EV Smart Charger → Entiteiten** en herlaad de integratie. Helper-entiteiten uitschakelen om functies die je niet gebruikt te verwijderen wordt niet ondersteund — open een issue als je liever een speciale opt-out wilt."
+    }
+  },
   "entity": {
     "switch": {
       "evsc_forza_ricarica": { "name": "Laad forceren" },

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -6,10 +6,12 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ev_smart_charger import (
     _async_register_frontend,
+    _entity_key_from_unique_id,
     async_setup_entry,
     async_unload_entry,
 )
@@ -185,6 +187,149 @@ async def test_async_setup_entry_raises_not_ready_on_registration_timeout(hass) 
     ):
         with pytest.raises(ConfigEntryNotReady):
             await async_setup_entry(hass, entry)
+
+
+def test_entity_key_from_unique_id_matches_evsc_pattern() -> None:
+    """Logical key is extracted from the EVSC unique_id format."""
+    key = _entity_key_from_unique_id(
+        f"{DOMAIN}_entry-1_evsc_forza_ricarica", "entry-1"
+    )
+    assert key == "evsc_forza_ricarica"
+
+
+def test_entity_key_from_unique_id_rejects_foreign_unique_id() -> None:
+    """Returns None for unique_ids belonging to other integrations."""
+    assert (
+        _entity_key_from_unique_id("some_other_integration_xyz", "entry-1") is None
+    )
+    # Wrong entry_id → another EVSC entry on the same registry.
+    assert (
+        _entity_key_from_unique_id(
+            f"{DOMAIN}_entry-2_evsc_forza_ricarica", "entry-1"
+        )
+        is None
+    )
+
+
+async def test_async_setup_entry_proceeds_with_user_disabled_helpers(hass) -> None:
+    """Regression for issue #22 (xion2000).
+
+    The user disabled a handful of helper entities (Night Charge / daily SOC
+    targets they didn't need). Those entities never call
+    ``async_added_to_hass`` so the registration barrier times out — but the
+    integration must still proceed in degraded mode and surface a Repairs
+    notice instead of failing setup.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=_entry_data(), entry_id="entry-1")
+    entry.add_to_hass(hass)
+    _stub_http(hass)
+
+    # Pre-populate the entity registry with 7 EVSC helpers all disabled by
+    # the user (mirrors the xion2000 scenario where Night Charge + daily SOC
+    # targets were turned off).
+    ent_reg = er.async_get(hass)
+    disabled_keys = [
+        "evsc_night_smart_charge_enabled",
+        "evsc_ev_min_soc_monday",
+        "evsc_ev_min_soc_tuesday",
+        "evsc_ev_min_soc_wednesday",
+        "evsc_ev_min_soc_thursday",
+        "evsc_ev_min_soc_friday",
+        "evsc_night_charge_amperage",
+    ]
+    for key in disabled_keys:
+        ent_reg.async_get_or_create(
+            domain="switch" if "enabled" in key else "number",
+            platform=DOMAIN,
+            unique_id=f"{DOMAIN}_entry-1_{key}",
+            config_entry=entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+
+    charger_controller = _component("charger")
+    ev_soc_monitor = _component("soc")
+    priority_balancer = _component("priority")
+    night_smart_charge = _component("night")
+    boost_charge = _component("boost")
+    smart_blocker = _component("blocker")
+    solar_surplus = _component("solar")
+    log_manager = _component("log")
+    diagnostic_manager = _component("diagnostic")
+    coordinator = SimpleNamespace()
+
+    async def forward_setups_partial(config_entry, platforms):
+        # Mirror reality — disabled entities never register, so the runtime
+        # count only includes the still-enabled ones.
+        runtime_data = config_entry.runtime_data
+        runtime_data.registered_entity_count = (
+            runtime_data.expected_entity_count - len(disabled_keys)
+        )
+        # Do NOT set runtime_data.registration_event — the wait_for must
+        # actually time out for the new branch to trigger.
+
+    async def timeout_wait_for(awaitable, timeout):
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()
+        raise TimeoutError
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=forward_setups_partial,
+        autospec=True,
+    ), patch(
+        "custom_components.ev_smart_charger.asyncio.wait_for",
+        side_effect=timeout_wait_for,
+    ), patch(
+        "custom_components.ev_smart_charger.ChargerController",
+        return_value=charger_controller,
+    ), patch(
+        "custom_components.ev_smart_charger.EVSOCMonitor",
+        return_value=ev_soc_monitor,
+    ), patch(
+        "custom_components.ev_smart_charger.AutomationCoordinator",
+        return_value=coordinator,
+    ), patch(
+        "custom_components.ev_smart_charger.DiagnosticManager",
+        return_value=diagnostic_manager,
+    ), patch(
+        "custom_components.ev_smart_charger.PriorityBalancer",
+        return_value=priority_balancer,
+    ), patch(
+        "custom_components.ev_smart_charger.NightSmartCharge",
+        return_value=night_smart_charge,
+    ), patch(
+        "custom_components.ev_smart_charger.BoostCharge",
+        return_value=boost_charge,
+    ), patch(
+        "custom_components.ev_smart_charger.SmartChargerBlocker",
+        return_value=smart_blocker,
+    ), patch(
+        "custom_components.ev_smart_charger.SolarSurplusAutomation",
+        return_value=solar_surplus,
+    ), patch(
+        "custom_components.ev_smart_charger.LogManager",
+        return_value=log_manager,
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    # Setup completed despite the timeout — the integration proceeded in
+    # degraded mode because all "missing" entities are accounted for as
+    # user-disabled.
+    assert result is True
+    assert entry.runtime_data is not None
+
+    # A Repairs entry was created so the user sees a clear explanation.
+    issue_reg = ir.async_get(hass)
+    issue = issue_reg.async_get_issue(DOMAIN, f"disabled_helpers_{entry.entry_id}")
+    assert issue is not None
+    assert issue.translation_key == "disabled_helpers"
+    assert issue.severity == ir.IssueSeverity.WARNING
+    placeholders = issue.translation_placeholders or {}
+    assert placeholders.get("count") == str(len(disabled_keys))
+    # Preview lists the disabled keys (sorted, truncated to 8).
+    assert "evsc_night_smart_charge_enabled" in placeholders.get("entities", "")
 
 
 async def test_async_setup_entry_cleans_up_diagnostic_manager_on_late_failure(hass) -> None:


### PR DESCRIPTION
## Summary

Fixes [#22](https://github.com/antbald/ha-ev-smart-charger/issues/22) (reported by @xion2000) and is Stage 1 of [#24](https://github.com/antbald/ha-ev-smart-charger/issues/24). The integration could not initialize after a HA restart when the user had manually disabled any helper entity — the Phase 1 registration barrier waited on a counter that never reaches the expected value because HA skips `async_added_to_hass` for disabled entities. Setup timed out with an opaque `ConfigEntryNotReady`.

> Version note: this branch was originally numbered v1.11.1, but [v1.11.1](https://github.com/antbald/ha-ev-smart-charger/releases/tag/v1.11.1) shipped meanwhile with the dashboard responsive fix. Rebased onto master and bumped to **v1.11.2**.

## What changed

New helper `_async_wait_for_helper_registration()` in [`__init__.py`](custom_components/ev_smart_charger/__init__.py) replaces the inline `try/except asyncio.wait_for`. On timeout it inspects `entity_registry` for `disabled_by != None` and:

- **`registered + disabled >= expected`** → user consciously turned them off. Log a `WARNING`, surface a Home Assistant Repairs entry (`translation_key="disabled_helpers"`, severity `WARNING`, EN/IT/NL), proceed in degraded mode. `state_helper` already defaults safely on `None`/`unknown`/`unavailable`.
- **Real shortfall** → log an `ERROR` listing the truly missing keys and raise `ConfigEntryNotReady` so HA retries setup.

The Repairs entry is cleared automatically on the next clean boot.

## Safety check

Spot-checked every reader of the kill switch `evsc_forza_ricarica` ([`automation_coordinator.py:65`](custom_components/ev_smart_charger/automation_coordinator.py#L65), [`automations.py:410`](custom_components/ev_smart_charger/automations.py#L410), [`solar_surplus.py:420`](custom_components/ev_smart_charger/solar_surplus.py#L420)). All use `if self._forza_ricarica_entity:` or `state_helper.get_bool(..., default=False)` guards — disabled helper = neutral kill switch OFF. Same pattern across the other helper lookups, so degraded mode is safe by construction.

## Test plan

- [x] New unit tests for `_entity_key_from_unique_id` (matches valid EVSC unique_ids, rejects foreign + cross-entry unique_ids).
- [x] New integration test `test_async_setup_entry_proceeds_with_user_disabled_helpers` that mirrors @xion2000's exact configuration: 7 EVSC helpers pre-disabled with `RegistryEntryDisabler.USER`, `registration_event` never fires, asserts `async_setup_entry` returns `True` and a Repairs entry exists with the expected placeholders.
- [x] Pre-existing `test_async_setup_entry_raises_not_ready_on_registration_timeout` still passes (genuine shortfall path).
- [x] Full test suite: 116 → 119 passing on the branch. The 22 pre-existing failures on master are unrelated.
- [x] CI Hassfest failures on this PR are pre-existing on master (manifest `icon` key, translation state key `EV`, missing `lovelace`/`http` deps) — verified the same failures appear on master HEAD and predate this PR.
- [ ] @xion2000 confirms the integration starts after a HA restart with his disabled entities still off (asked on #22).

## Files

- `custom_components/ev_smart_charger/__init__.py` — new constant + 4 helpers, Phase 1 try/except collapsed into a single call.
- `custom_components/ev_smart_charger/const.py`, `manifest.json` — bump to v1.11.2.
- `custom_components/ev_smart_charger/strings.json`, `translations/en.json`, `translations/it.json`, `translations/nl.json` — new top-level `issues.disabled_helpers` block.
- `tests/test_integration_setup.py` — three new tests.
- `CLAUDE.md` — v1.11.2 entry in the Version History (above the v1.11.1 dashboard entry).

## Backward compatibility

Zero schema / entity / API changes. No config-flow steps added. The happy path returns from the new helper exactly as before — only the failure branch is new.

## Follow-up — out of scope for this PR

The proper fix is to extend the v1.7.0 PV-only mode pattern (`has_home_battery(config)` → skip helpers) to other feature groups so users can opt out of features they don't want without resorting to disabling entities by hand. Tracked separately on #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)