### PR TITLE
v2.0.0 — Universal compatibility: three-phase support + charger model (Tuya/generic)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is a **Home Assistant custom integration** for intelligent EV charging control. It manages EV charger automation based on solar production, time of day, battery levels, grid import protection, and intelligent priority balancing between EV and home battery charging.
 
 **Domain:** `ev_smart_charger`
-**Current Version:** 1.8.0
+**Current Version:** 2.0.0
 **Installation:** HACS custom repository or manual installation to `custom_components/ev_smart_charger`
 
 ## Development Commands
@@ -391,7 +391,7 @@ This allows automations to find helper entities regardless of entry_id.
 
 **Integration Metadata:**
 - `DOMAIN = "ev_smart_charger"`
-- `VERSION = "1.4.14"`
+- `VERSION = "2.0.0"`
 - `DEFAULT_NAME = "EV Smart Charger"`
 
 **Platforms:**
@@ -755,6 +755,34 @@ async def _set_amperage(self, target_amperage: int):
 - **Sensor Unavailability:** When amperage sensor returns None/unavailable (e.g., charger offline), `get_int(entity, default=None)` returns None without warnings (v1.3.7+). The system maintains current state until sensor becomes available again.
 
 ## Version History
+
+### v2.0.0 (2026-05-29) — MAJOR
+**Universal compatibility: any electrical system (single-phase / three-phase) + any wallbox (Tuya / generic, cloud or local) — opt-in ([discussion #18](https://github.com/antbald/ha-ev-smart-charger/discussions/18))**
+
+Major version: EV Smart Charger now covers *every* installation shape on the market (1φ/3φ, any HA-integrated wallbox). But it is **100% backward compatible** — existing installs default to single-phase + Tuya, no migration, no behaviour change.
+
+Two independent opt-in dimensions, both defaulting to the current behaviour so existing installs are byte-for-byte unchanged (no migration; missing keys resolve to defaults via `.get`).
+
+**1. Phase mode (`CONF_PHASE_MODE` = `single` default | `three`).**
+In three-phase, production / home-consumption / grid-import are mapped as **three sensors each** (L1 reuses the existing single-phase key; L2/L3 are new keys, required only in three-phase) and summed. The watt→amp conversion uses an **effective voltage** of `phase_count × 230` (690 V in three-phase) instead of 230 V — so `surplus_amps = surplus_watts / effective_voltage` yields the per-phase amperage a balanced three-phase charger sustains (P = 3·V·I), and all downstream amperage thresholds / levels / caps stay valid unchanged. SOC sensors stay single (battery percentages, not per-phase).
+
+**2. Charger model (`CONF_CHARGER_MODEL` = `tuya` default | `generic`).** Governs two behaviours:
+- **Granularity**: `tuya` keeps discrete `CHARGER_AMP_LEVELS` `[6,8,10,13,16,20,24,32]`; `generic` uses 1 A steps `GENERIC_AMP_LEVELS = range(6,33)`. The amperage `number` entities use `step=1` in generic mode.
+- **Decrease sequence**: `tuya` keeps the safe stop → set → start sequence (Tuya/`select` chargers misbehave on a live current change); `generic` lowers the current **live, without stopping** the charger (non-Tuya `number`-controlled wallboxes accept it). The existing `CurrentControlAdapter` (number/input_number/select/input_select) already handled non-Tuya wallbox *control*; v2.0.0 adds the granularity + live-decrease that completes it.
+
+**Architecture — single source of truth.** New `power_model.py` defines `ChargingModel` (phase_count, effective_voltage, amp_levels, charger_model, per-phase power readers). Built once in `__init__` and stored on `runtime_data.power_model`; consumed by `charger_controller`, `solar_surplus`, `night_smart_charge`, `hybrid_inverter_mode`. Pure config helpers (`is_three_phase`, `get_phase_count`, `get_effective_voltage`, `get_amp_levels`, `get_charger_model`) live in `const.py` for the config flow / `number.py` / `dashboard_manager` (which run without runtime_data).
+
+**Config flow.** Initial flow 7 → **9 steps** (name → phase_mode → charger_model → entities → sensors[phase-aware] → pv_forecast → notifications → external_connectors → dashboard). Reconfigure & options flows mirror it (6 → **8 steps**; entry point becomes phase_mode, charger-entities moved to a dedicated step) so existing users can opt in. Radio labels are localized in Python (cross-HA-version safe; older cores reject `translation_key` during selector serialization); step titles/descriptions in `strings.json` + EN/IT/NL with the R1 power note.
+
+**Dashboard.** `dashboard_manager` passes `phase_mode`, `charger_model` and per-phase entity lists; the bundled card whitelists them in `setConfig` (the v1.11.13 silent-drop class of bug), sums the phase sensors for the Solar/Grid tiles, and derives charging power with `amps × 690` in three-phase.
+
+**Known limitation (R1, documented not capped).** All amperage settings are per-phase, so in three-phase each means ~3× the single-phase power (16 A ≈ 11 kW; minimum ~4.1 kW). Battery support / night charge can exceed a home battery inverter's discharge limit — documented in the config flow + README; a power cap is a possible follow-up. Telemetry intentionally untouched (fixed GAS schema).
+
+**Files**: NEW `power_model.py`; `const.py`, `runtime.py`, `__init__.py`, `utils/amperage_helper.py`, `charger_controller.py`, `solar_surplus.py`, `night_smart_charge.py`, `hybrid_inverter_mode.py`, `number.py`, `config_flow.py`, `dashboard_manager.py`, `frontend/ev-smart-charger-dashboard.js`, `strings.json`, `translations/{en,it,nl}.json`, `manifest.json`, `docs/SSOT.md`, `docs/CODEBASE_MAP.md`, `README.md`, `info.md`; tests: NEW `tests/test_power_model_and_charger_model.py`, updated `tests/test_config_flow*.py`. `VERSION = "2.0.0"`. Entity counts unchanged (phase/model are config, not helpers).
+
+**Upgrade priority**: 🟢 RECOMMENDED for three-phase / non-Tuya wallbox owners (opt-in via reconfigure). ⚪ NO-OP for everyone else — defaults preserve single-phase + Tuya behaviour exactly.
+
+---
 
 ### v1.11.7 (2026-05-27)
 **HOTFIX: Boost rejection visibility + Charging Power lenient computation**

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # ⚡ EV Smart Charger
 
-### Intelligent EV charging orchestration for Home Assistant
+### The universal EV charging solution for Home Assistant — *any* electrical system, *any* wallbox
 
-Maximise solar self-consumption · balance EV vs home battery · automate overnight charging · ride curtailment on zero-export inverters — all from a single Liquid Glass dashboard.
+**One integration for every setup.** Single-phase or three-phase. Tuya or any other wallbox. Cloud-connected or local. If your charger has a Home Assistant integration — cloud *or* local — and exposes its current as a `number`, `select`, `input_number` or `input_select` entity, **this works with it.** Maximise solar self-consumption · balance EV vs home battery · automate overnight charging · ride curtailment on zero-export inverters — all from a single Liquid Glass dashboard.
 
 [![GitHub Release](https://img.shields.io/github/v/release/antbald/ha-ev-smart-charger?style=for-the-badge&logo=github&color=007AFF)](https://github.com/antbald/ha-ev-smart-charger/releases)
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-FF6F00?style=for-the-badge&logo=home-assistant&logoColor=white)](https://github.com/custom-components/hacs)
@@ -32,9 +32,23 @@ Most "smart charging" integrations stop at "use solar surplus". This one orchest
 - ⚡ **Boost Charge** — manual or scheduled high-priority session with automatic SOC stop.
 - 🛡️ **Smart Charger Blocker** — prevents charging outside your allowed window (sunset → night-charge time, or sunset → sunrise).
 - ⚡ **Hybrid Inverter Mode** *(v1.8.0+)* — empirically probes for hidden PV capacity in zero-export hybrid systems (Deye, Sunsynk, Solis, Growatt, Goodwe…). Solves [issue #20](https://github.com/antbald/ha-ev-smart-charger/issues/20).
+- 🔌 **Three-phase + charger model** *(v2.0.0+)* — opt-in three-phase support (three production/consumption/grid sensors, speed balanced across phases) and a Tuya / generic wallbox selector (generic = 1 A steps + live current decrease). Defaults keep single-phase + Tuya unchanged. Solves [discussion #18](https://github.com/antbald/ha-ev-smart-charger/discussions/18).
 - 💾 **Cached EV SOC** — reliable fallback for flaky cloud-based car integrations.
 
-> **🎉 New in v1.10.0** — The bundled dashboard now splits into **Dashboard** (operational) and **Settings** (configuration) tabs. Every parameter is grouped under an expandable category with a full multilingual description (EN / IT / NL, picked from your HA profile automatically). [Jump to the preview ↓](#-preview)
+### 🌍 Universal by design
+
+Most projects target one charger brand or assume a single-phase home. EV Smart Charger is built to be the **one integration that fits every installation**:
+
+| Dimension | What's supported |
+|---|---|
+| **Electrical system** | ✅ Single-phase **and** three-phase (opt-in; speed balanced across all three phases) |
+| **Wallbox brand** | ✅ Tuya **and** any other — no brand lock-in. The logic drives whatever entities your charger's HA integration exposes |
+| **Connectivity** | ✅ Cloud **or** local Home Assistant integration — if HA can see your charger, this can drive it |
+| **Current control** | ✅ `number`, `input_number`, `select`, `input_select` — discrete Tuya levels **or** 1 A fine steps (generic) |
+| **Home battery** | ✅ With **or** without — full PV-only mode when you have no battery |
+| **Inverter** | ✅ Standard **and** hybrid zero-export (Deye, Sunsynk, Solis, Growatt, Goodwe…) |
+
+> **🎉 New in v2.0.0** — Universal compatibility lands: opt-in **three-phase** support and a **Tuya / generic wallbox** selector mean EV Smart Charger now adapts to *any* solar + EV setup on the market. **Upgrading changes nothing for existing users** — defaults stay single-phase + Tuya, with no migration. [Jump to the setup ↓](#three-phase-support--charger-model--v200)
 
 ---
 
@@ -318,6 +332,24 @@ If you do not have a home battery installed, leave the **Home battery SOC** fiel
 - Hybrid Inverter Mode (v1.8.0+) is technically available but stays IDLE in PV-only mode — its entry conditions require a home battery SOC sensor.
 
 **Reconfigure restriction**: once a home battery sensor has been configured, the field stays required in the reconfigure / options flow. This prevents orphan helper entities from accumulating in the Home Assistant entity registry. To remove a home battery from an existing setup, delete the integration and add it again.
+
+---
+
+### Three-phase support + charger model — v2.0.0+
+
+Two opt-in choices appear in the first config-flow steps (and in Reconfigure / Options, so existing users can switch). Both default to the previous behaviour — **single-phase + Tuya** — so if you do nothing, nothing changes.
+
+**Phase mode**
+- **Single-phase** (default): one sensor each for solar production, home consumption and grid import; charging speed computed at 230 V. Identical to all previous versions.
+- **Three-phase**: you map **three sensors each** (one per phase L1/L2/L3) for production, consumption and grid import. The integration sums them and balances the charging speed across the three phases (conversion at 3 × 230 = 690 V). SOC sensors stay single.
+
+⚠️ **Power on three-phase**: every amperage setting is **per phase**, so it draws ~3× the power of single-phase. `16 A` ≈ **11 kW**, and the minimum a three-phase charger can draw is ~**4.1 kW** (6 A/phase). This matters for `evsc_battery_support_amperage` and `evsc_night_charge_amperage` — make sure your home-battery inverter can sustain the chosen power, otherwise the deficit is pulled from the grid and grid-import protection will throttle the session.
+
+**Charger model**
+- **Tuya** (default): current is set only to fixed levels `6/8/10/13/16/20/24/32 A`; to lower it the charger is switched off then back on (a few seconds' pause).
+- **Generic (1 A steps)**: for non-Tuya wallboxes that expose the current as a `number` entity. Any integer ampere (6–32) is allowed, and **lowering the current happens live without interrupting the session**. The amperage controls switch to 1 A steps.
+
+No data migration: existing config entries keep working unchanged. To enable three-phase or generic mode on an existing install, open the integration and run **Reconfigure** (or Configure / Options).
 
 ---
 

--- a/custom_components/ev_smart_charger/__init__.py
+++ b/custom_components/ev_smart_charger/__init__.py
@@ -44,6 +44,7 @@ from .night_smart_charge import NightSmartCharge
 from .boost_charge import BoostCharge
 from .automations import SmartChargerBlocker
 from .hybrid_inverter_mode import HybridInverterMode
+from .power_model import ChargingModel
 from .solar_surplus import SolarSurplusAutomation
 from .log_manager import LogManager
 from .diagnostic_manager import DiagnosticManager
@@ -122,6 +123,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         config=dict(entry.data),
         expected_entity_count=expected_entities,
     )
+    # v2.0.0: build the single source of truth for phase mode + charger model
+    # once, and share it across all runtime components via runtime_data.
+    runtime_data.power_model = ChargingModel.from_config(entry.data)
     entry.runtime_data = runtime_data
 
     _LOGGER.info("=" * 64)
@@ -129,6 +133,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.info(
         "🔋 Home battery: %s",
         "configured" if battery_configured else "NOT configured (PV-only mode)",
+    )
+    _LOGGER.info(
+        "⚡ Phase mode: %s (%.0f V) · Charger model: %s",
+        "three-phase" if runtime_data.power_model.phase_count == 3 else "single-phase",
+        runtime_data.power_model.effective_voltage,
+        runtime_data.power_model.charger_model,
     )
     _LOGGER.info("=" * 64)
 

--- a/custom_components/ev_smart_charger/charger_controller.py
+++ b/custom_components/ev_smart_charger/charger_controller.py
@@ -13,14 +13,16 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CHARGER_AMPERAGE_STABILIZATION_DELAY,
-    CHARGER_AMP_LEVELS,
     CHARGER_COMMAND_DELAY,
     CHARGER_MIN_OPERATION_INTERVAL,
+    CHARGER_MODEL_TUYA,
     CHARGER_START_SEQUENCE_DELAY,
     CHARGER_STOP_SEQUENCE_DELAY,
     CONF_EV_CHARGER_CURRENT,
     CONF_EV_CHARGER_SWITCH,
     SERVICE_CALL_TIMEOUT,
+    get_amp_levels,
+    get_charger_model,
 )
 from .runtime import EVSCRuntimeData
 from .utils.amperage_helper import AmperageCalculator
@@ -152,15 +154,21 @@ class ChargerController:
         self._charger_current = config.get(CONF_EV_CHARGER_CURRENT)
         self._current_control = CurrentControlAdapter(hass, self._charger_current)
 
+        # Charger model (v2.0.0): governs the amperage level set and whether the
+        # safe stop/set/start decrease sequence is used (tuya) or a live set (generic).
+        self._amp_levels = get_amp_levels(config)
+        self._charger_model = get_charger_model(config)
+
         self._last_operation_time: Optional[datetime] = None
         self._current_amperage: Optional[int] = None
         self._is_on: Optional[bool] = None
         self._lock = asyncio.Lock()
 
         self.logger.info(
-            "Initialized ChargerController - Switch: %s, Current: %s",
+            "Initialized ChargerController - Switch: %s, Current: %s, Model: %s",
             self._charger_switch,
             self._charger_current,
+            self._charger_model,
         )
 
     async def _emit_operation_diagnostic(
@@ -394,7 +402,9 @@ class ChargerController:
                 await self._refresh_state()
 
                 current_amps = self._current_amperage or 0
-                next_amps = AmperageCalculator.get_next_level_down(current_amps)
+                next_amps = AmperageCalculator.get_next_level_down(
+                    current_amps, self._amp_levels
+                )
                 await self._wait_for_rate_limit()
 
                 if next_amps == 0:
@@ -462,6 +472,7 @@ class ChargerController:
                 next_amps = AmperageCalculator.get_next_level_up(
                     current_amps,
                     normalized_target,
+                    self._amp_levels,
                 )
                 operation = await self._set_amperage_unlocked(next_amps)
                 return OperationResult(
@@ -509,12 +520,22 @@ class ChargerController:
         await self._refresh_state()
 
     async def _set_amperage_unlocked(self, target_amps: int) -> str:
-        """Set charger amperage without reacquiring the controller lock."""
+        """Set charger amperage without reacquiring the controller lock.
+
+        On DECREASE, Tuya chargers need the safe stop/set/start sequence
+        (changing current while charging misbehaves). Generic (non-Tuya)
+        wallboxes accept a live current reduction, so we set the lower value
+        directly — no stop, no ~6-8s interruption per step (v2.0.0).
+        """
         await self._refresh_state()
         current_amps = self._current_amperage or 0
         is_on = bool(self._is_on)
 
-        if is_on and target_amps < current_amps:
+        if (
+            is_on
+            and target_amps < current_amps
+            and self._charger_model == CHARGER_MODEL_TUYA
+        ):
             await self._decrease_amperage_unlocked(target_amps)
             return "adjust_down"
 
@@ -567,8 +588,8 @@ class ChargerController:
     def _normalize_target_amps(self, target_amps: int | float | None) -> int:
         """Normalize a target amperage to the nearest supported level."""
         if target_amps is None:
-            return CHARGER_AMP_LEVELS[0]
-        return min(CHARGER_AMP_LEVELS, key=lambda value: abs(value - int(target_amps)))
+            return self._amp_levels[0]
+        return min(self._amp_levels, key=lambda value: abs(value - int(target_amps)))
 
     async def _call_service(self, domain: str, service: str, data: dict):
         """Call a Home Assistant service with timeout and error handling."""

--- a/custom_components/ev_smart_charger/config_flow.py
+++ b/custom_components/ev_smart_charger/config_flow.py
@@ -11,25 +11,40 @@ from homeassistant.helpers import selector
 from .const import (
     CONF_BATTERY_CAPACITY,
     CONF_CAR_OWNER,
+    CONF_CHARGER_MODEL,
     CONF_CREATE_DASHBOARD,
     CONF_ENERGY_FORECAST_TARGET,
     CONF_EV_CHARGER_CURRENT,
     CONF_EV_CHARGER_STATUS,
     CONF_EV_CHARGER_SWITCH,
     CONF_FV_PRODUCTION,
+    CONF_FV_PRODUCTION_L2,
+    CONF_FV_PRODUCTION_L3,
     CONF_GRID_IMPORT,
+    CONF_GRID_IMPORT_L2,
+    CONF_GRID_IMPORT_L3,
     CONF_HOME_CONSUMPTION,
+    CONF_HOME_CONSUMPTION_L2,
+    CONF_HOME_CONSUMPTION_L3,
     CONF_NOTIFY_SERVICES,
+    CONF_PHASE_MODE,
     CONF_PV_FORECAST,
     CONF_PV_FORECAST_TOMORROW,
     CONF_SOC_CAR,
     CONF_SOC_HOME,
+    CHARGER_MODEL_GENERIC,
+    CHARGER_MODEL_TUYA,
     DEFAULT_BATTERY_CAPACITY,
+    DEFAULT_CHARGER_MODEL,
     DEFAULT_CREATE_DASHBOARD,
     DEFAULT_NAME,
+    DEFAULT_PHASE_MODE,
     DOMAIN,
     MAX_BATTERY_CAPACITY,
     MIN_BATTERY_CAPACITY,
+    PHASE_MODE_SINGLE,
+    PHASE_MODE_THREE,
+    is_three_phase,
 )
 
 CURRENT_CONTROL_DOMAINS = ["number", "select", "input_number", "input_select"]
@@ -121,8 +136,75 @@ def _charger_schema(current_data: dict[str, Any] | None = None) -> vol.Schema:
     )
 
 
-def _sensor_schema(current_data: dict[str, Any] | None = None) -> vol.Schema:
-    """Build the sensor mapping schema."""
+# v2.0.0: radio option labels per language. The longer per-option explanations
+# live in strings.json step `description` (which HA localizes normally); these are
+# just the short radio labels. Localized in Python — instead of a selector
+# `translation_key` — so it works across HA versions (older cores reject
+# translation_key on a SelectSelectorConfig during form serialization).
+_RADIO_LABELS: dict[str, dict[str, dict[str, str]]] = {
+    CONF_PHASE_MODE: {
+        "en": {PHASE_MODE_SINGLE: "Single-phase", PHASE_MODE_THREE: "Three-phase"},
+        "it": {PHASE_MODE_SINGLE: "Monofase", PHASE_MODE_THREE: "Trifase"},
+        "nl": {PHASE_MODE_SINGLE: "Eénfase", PHASE_MODE_THREE: "Driefase"},
+    },
+    CONF_CHARGER_MODEL: {
+        "en": {CHARGER_MODEL_TUYA: "Tuya (standard)", CHARGER_MODEL_GENERIC: "Generic (1 A steps)"},
+        "it": {CHARGER_MODEL_TUYA: "Tuya (standard)", CHARGER_MODEL_GENERIC: "Generica (scatti da 1 A)"},
+        "nl": {CHARGER_MODEL_TUYA: "Tuya (standaard)", CHARGER_MODEL_GENERIC: "Generiek (stappen van 1 A)"},
+    },
+}
+
+
+def _radio_schema(hass, key: str, options: list[str], current_value: str) -> vol.Schema:
+    """Build a single-field radio (SelectSelector LIST) schema with i18n labels."""
+    lang = (getattr(hass.config, "language", None) or "en") if hass else "en"
+    labels = _RADIO_LABELS[key].get(lang) or _RADIO_LABELS[key]["en"]
+    return vol.Schema(
+        {
+            vol.Required(key, default=current_value): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {"value": opt, "label": labels.get(opt, opt)} for opt in options
+                    ],
+                    mode=selector.SelectSelectorMode.LIST,
+                )
+            )
+        }
+    )
+
+
+def _phase_mode_schema(hass, current_data: dict[str, Any] | None = None) -> vol.Schema:
+    """Build the phase-mode radio schema (single / three) — v2.0.0."""
+    current_data = current_data or {}
+    return _radio_schema(
+        hass,
+        CONF_PHASE_MODE,
+        [PHASE_MODE_SINGLE, PHASE_MODE_THREE],
+        current_data.get(CONF_PHASE_MODE, DEFAULT_PHASE_MODE),
+    )
+
+
+def _charger_model_schema(hass, current_data: dict[str, Any] | None = None) -> vol.Schema:
+    """Build the charger-model radio schema (tuya / generic) — v2.0.0."""
+    current_data = current_data or {}
+    return _radio_schema(
+        hass,
+        CONF_CHARGER_MODEL,
+        [CHARGER_MODEL_TUYA, CHARGER_MODEL_GENERIC],
+        current_data.get(CONF_CHARGER_MODEL, DEFAULT_CHARGER_MODEL),
+    )
+
+
+def _sensor_schema(
+    current_data: dict[str, Any] | None = None,
+    three_phase: bool = False,
+) -> vol.Schema:
+    """Build the sensor mapping schema.
+
+    v2.0.0: in three-phase mode, production / home-consumption / grid-import are
+    asked as three sensors each (L1 reuses the existing single-phase key, L2/L3
+    are required). SOC sensors stay single (battery percentages, not per-phase).
+    """
     current_data = current_data or {}
 
     # v1.7.0: `soc_home` is optional. To prevent orphan helper entities, once a
@@ -132,18 +214,23 @@ def _sensor_schema(current_data: dict[str, Any] | None = None) -> vol.Schema:
     existing_soc_home = current_data.get(CONF_SOC_HOME)
     soc_home_marker = vol.Required if existing_soc_home else vol.Optional
 
-    return vol.Schema(
-        {
-            vol.Required(CONF_SOC_CAR, **_field_config(current_data.get(CONF_SOC_CAR))): _entity_selector("sensor"),
-            soc_home_marker(CONF_SOC_HOME, **_field_config(existing_soc_home)): _entity_selector("sensor"),
-            vol.Required(CONF_FV_PRODUCTION, **_field_config(current_data.get(CONF_FV_PRODUCTION))): _entity_selector("sensor"),
-            vol.Required(
-                CONF_HOME_CONSUMPTION,
-                **_field_config(current_data.get(CONF_HOME_CONSUMPTION)),
-            ): _entity_selector("sensor"),
-            vol.Required(CONF_GRID_IMPORT, **_field_config(current_data.get(CONF_GRID_IMPORT))): _entity_selector("sensor"),
-        }
-    )
+    fields: dict[Any, Any] = {
+        vol.Required(CONF_SOC_CAR, **_field_config(current_data.get(CONF_SOC_CAR))): _entity_selector("sensor"),
+        soc_home_marker(CONF_SOC_HOME, **_field_config(existing_soc_home)): _entity_selector("sensor"),
+    }
+
+    # Per-quantity power sensors, grouped L1[/L2/L3]. Single-phase = L1 only.
+    for l1, l2, l3 in (
+        (CONF_FV_PRODUCTION, CONF_FV_PRODUCTION_L2, CONF_FV_PRODUCTION_L3),
+        (CONF_HOME_CONSUMPTION, CONF_HOME_CONSUMPTION_L2, CONF_HOME_CONSUMPTION_L3),
+        (CONF_GRID_IMPORT, CONF_GRID_IMPORT_L2, CONF_GRID_IMPORT_L3),
+    ):
+        fields[vol.Required(l1, **_field_config(current_data.get(l1)))] = _entity_selector("sensor")
+        if three_phase:
+            fields[vol.Required(l2, **_field_config(current_data.get(l2)))] = _entity_selector("sensor")
+            fields[vol.Required(l3, **_field_config(current_data.get(l3)))] = _entity_selector("sensor")
+
+    return vol.Schema(fields)
 
 
 def _pv_forecast_schema(current_data: dict[str, Any] | None = None) -> vol.Schema:
@@ -241,6 +328,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize mutable flow state."""
         self.init_info: dict[str, Any] = {}
+        self.mode_info: dict[str, Any] = {}  # v2.0.0: phase_mode + charger_model
         self.charger_info: dict[str, Any] = {}
         self.sensor_info: dict[str, Any] = {}
         self.pv_forecast_info: dict[str, Any] = {}
@@ -252,13 +340,39 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step where user provides a name."""
         if user_input is not None:
             self.init_info = user_input
-            return await self.async_step_entities()
+            return await self.async_step_phase_mode()
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({vol.Optional(CONF_NAME, default=DEFAULT_NAME): str}),
             errors={},
-            description_placeholders={"step": "1", "total_steps": "7"},
+            description_placeholders={"step": "1", "total_steps": "9"},
+        )
+
+    async def async_step_phase_mode(self, user_input: dict[str, Any] | None = None):
+        """Handle the phase-mode selection step (single / three) — v2.0.0."""
+        if user_input is not None:
+            self.mode_info.update(user_input)
+            return await self.async_step_charger_model()
+
+        return self.async_show_form(
+            step_id="phase_mode",
+            data_schema=_phase_mode_schema(self.hass),
+            errors={},
+            description_placeholders={"step": "2", "total_steps": "9"},
+        )
+
+    async def async_step_charger_model(self, user_input: dict[str, Any] | None = None):
+        """Handle the charger-model selection step (tuya / generic) — v2.0.0."""
+        if user_input is not None:
+            self.mode_info.update(user_input)
+            return await self.async_step_entities()
+
+        return self.async_show_form(
+            step_id="charger_model",
+            data_schema=_charger_model_schema(self.hass),
+            errors={},
+            description_placeholders={"step": "3", "total_steps": "9"},
         )
 
     async def async_step_entities(self, user_input: dict[str, Any] | None = None):
@@ -275,7 +389,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="entities",
             data_schema=_charger_schema(),
             errors=errors,
-            description_placeholders={"step": "2", "total_steps": "7"},
+            description_placeholders={"step": "4", "total_steps": "9"},
         )
 
     async def async_step_sensors(self, user_input: dict[str, Any] | None = None):
@@ -286,9 +400,9 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="sensors",
-            data_schema=_sensor_schema(),
+            data_schema=_sensor_schema(three_phase=is_three_phase(self.mode_info)),
             errors={},
-            description_placeholders={"step": "3", "total_steps": "7"},
+            description_placeholders={"step": "5", "total_steps": "9"},
         )
 
     async def async_step_pv_forecast(self, user_input: dict[str, Any] | None = None):
@@ -301,7 +415,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="pv_forecast",
             data_schema=_pv_forecast_schema(),
             errors={},
-            description_placeholders={"step": "4", "total_steps": "7"},
+            description_placeholders={"step": "6", "total_steps": "9"},
         )
 
     async def async_step_notifications(self, user_input: dict[str, Any] | None = None):
@@ -314,7 +428,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="notifications",
             data_schema=_notifications_schema(self.hass),
             errors={},
-            description_placeholders={"step": "5", "total_steps": "7"},
+            description_placeholders={"step": "7", "total_steps": "9"},
         )
 
     async def async_step_external_connectors(self, user_input: dict[str, Any] | None = None):
@@ -331,7 +445,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="external_connectors",
             data_schema=_external_connectors_schema(),
             errors=errors,
-            description_placeholders={"step": "6", "total_steps": "7"},
+            description_placeholders={"step": "8", "total_steps": "9"},
         )
 
     async def async_step_dashboard(self, user_input: dict[str, Any] | None = None):
@@ -340,6 +454,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data = _merge_entry_data(
                 {},
                 self.init_info,
+                self.mode_info,
                 self.charger_info,
                 self.sensor_info,
                 self.pv_forecast_info,
@@ -354,17 +469,43 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="dashboard",
             data_schema=_dashboard_schema(),
             errors={},
-            description_placeholders={"step": "7", "total_steps": "7"},
+            description_placeholders={"step": "9", "total_steps": "9"},
         )
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
-        """Handle native reconfiguration for existing config entries."""
+        """Reconfigure entry point: phase-mode selection (v2.0.0)."""
         self._reconfigure_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
         if self._reconfigure_entry is None:
             return self.async_abort(reason="unknown_entry")
 
+        if user_input is not None:
+            self.mode_info.update(user_input)
+            return await self.async_step_reconfigure_charger_model()
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_phase_mode_schema(self.hass, self._reconfigure_entry.data),
+            errors={},
+            description_placeholders={"step": "1", "total_steps": "8"},
+        )
+
+    async def async_step_reconfigure_charger_model(self, user_input: dict[str, Any] | None = None):
+        """Charger-model selection during reconfigure (v2.0.0)."""
+        if user_input is not None:
+            self.mode_info.update(user_input)
+            return await self.async_step_reconfigure_entities()
+
+        return self.async_show_form(
+            step_id="reconfigure_charger_model",
+            data_schema=_charger_model_schema(self.hass, self._reconfigure_entry.data),
+            errors={},
+            description_placeholders={"step": "2", "total_steps": "8"},
+        )
+
+    async def async_step_reconfigure_entities(self, user_input: dict[str, Any] | None = None):
+        """Charger entity remapping during reconfigure."""
         if user_input is not None:
             if _is_duplicate_charger_switch(
                 self.hass,
@@ -376,10 +517,10 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_reconfigure_sensors()
 
         return self.async_show_form(
-            step_id="reconfigure",
+            step_id="reconfigure_entities",
             data_schema=_charger_schema(self._reconfigure_entry.data),
             errors={},
-            description_placeholders={"step": "1", "total_steps": "6"},
+            description_placeholders={"step": "3", "total_steps": "8"},
         )
 
     async def async_step_reconfigure_sensors(self, user_input: dict[str, Any] | None = None):
@@ -390,9 +531,12 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure_sensors",
-            data_schema=_sensor_schema(self._reconfigure_entry.data),
+            data_schema=_sensor_schema(
+                self._reconfigure_entry.data,
+                three_phase=is_three_phase(self.mode_info),
+            ),
             errors={},
-            description_placeholders={"step": "2", "total_steps": "6"},
+            description_placeholders={"step": "4", "total_steps": "8"},
         )
 
     async def async_step_reconfigure_pv_forecast(self, user_input: dict[str, Any] | None = None):
@@ -405,7 +549,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reconfigure_pv_forecast",
             data_schema=_pv_forecast_schema(self._reconfigure_entry.data),
             errors={},
-            description_placeholders={"step": "3", "total_steps": "6"},
+            description_placeholders={"step": "5", "total_steps": "8"},
         )
 
     async def async_step_reconfigure_notifications(self, user_input: dict[str, Any] | None = None):
@@ -418,7 +562,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reconfigure_notifications",
             data_schema=_notifications_schema(self.hass, self._reconfigure_entry.data),
             errors={},
-            description_placeholders={"step": "4", "total_steps": "6"},
+            description_placeholders={"step": "6", "total_steps": "8"},
         )
 
     async def async_step_reconfigure_external_connectors(
@@ -438,7 +582,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reconfigure_external_connectors",
             data_schema=_external_connectors_schema(self._reconfigure_entry.data),
             errors=errors,
-            description_placeholders={"step": "5", "total_steps": "6"},
+            description_placeholders={"step": "7", "total_steps": "8"},
         )
 
     async def async_step_reconfigure_dashboard(
@@ -448,6 +592,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             updated_data = _merge_entry_data(
                 self._reconfigure_entry.data,
+                self.mode_info,
                 self.charger_info,
                 self.sensor_info,
                 self.pv_forecast_info,
@@ -466,7 +611,7 @@ class EVSCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reconfigure_dashboard",
             data_schema=_dashboard_schema(self._reconfigure_entry.data),
             errors={},
-            description_placeholders={"step": "6", "total_steps": "6"},
+            description_placeholders={"step": "8", "total_steps": "8"},
         )
 
     def _get_mobile_notify_services(self) -> list[str]:
@@ -486,6 +631,7 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
     def __init__(self, config_entry):
         """Initialize options flow."""
         super().__init__(config_entry)
+        self.mode_info: dict[str, Any] = {}  # v2.0.0: phase_mode + charger_model
         self.charger_info: dict[str, Any] = {}
         self.sensor_info: dict[str, Any] = {}
         self.pv_forecast_info: dict[str, Any] = {}
@@ -493,6 +639,30 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
         self.external_info: dict[str, Any] = {}
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        """Options entry point: phase-mode selection (v2.0.0)."""
+        if user_input is not None:
+            self.mode_info.update(user_input)
+            return await self.async_step_charger_model()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_phase_mode_schema(self.hass, self.config_entry.data),
+            description_placeholders={"step": "1", "total_steps": "8"},
+        )
+
+    async def async_step_charger_model(self, user_input: dict[str, Any] | None = None):
+        """Charger-model selection (tuya / generic) — v2.0.0."""
+        if user_input is not None:
+            self.mode_info.update(user_input)
+            return await self.async_step_entities()
+
+        return self.async_show_form(
+            step_id="charger_model",
+            data_schema=_charger_model_schema(self.hass, self.config_entry.data),
+            description_placeholders={"step": "2", "total_steps": "8"},
+        )
+
+    async def async_step_entities(self, user_input: dict[str, Any] | None = None):
         """Manage charger entities options."""
         if user_input is not None:
             if _is_duplicate_charger_switch(
@@ -505,9 +675,9 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
             return await self.async_step_sensors()
 
         return self.async_show_form(
-            step_id="init",
+            step_id="entities",
             data_schema=_charger_schema(self.config_entry.data),
-            description_placeholders={"step": "1", "total_steps": "6"},
+            description_placeholders={"step": "3", "total_steps": "8"},
         )
 
     async def async_step_sensors(self, user_input: dict[str, Any] | None = None):
@@ -518,8 +688,11 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
 
         return self.async_show_form(
             step_id="sensors",
-            data_schema=_sensor_schema(self.config_entry.data),
-            description_placeholders={"step": "2", "total_steps": "6"},
+            data_schema=_sensor_schema(
+                self.config_entry.data,
+                three_phase=is_three_phase(self.mode_info),
+            ),
+            description_placeholders={"step": "4", "total_steps": "8"},
         )
 
     async def async_step_pv_forecast(self, user_input: dict[str, Any] | None = None):
@@ -531,7 +704,7 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
         return self.async_show_form(
             step_id="pv_forecast",
             data_schema=_pv_forecast_schema(self.config_entry.data),
-            description_placeholders={"step": "3", "total_steps": "6"},
+            description_placeholders={"step": "5", "total_steps": "8"},
         )
 
     async def async_step_notifications(self, user_input: dict[str, Any] | None = None):
@@ -543,7 +716,7 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
         return self.async_show_form(
             step_id="notifications",
             data_schema=_notifications_schema(self.hass, self.config_entry.data),
-            description_placeholders={"step": "4", "total_steps": "6"},
+            description_placeholders={"step": "6", "total_steps": "8"},
         )
 
     async def async_step_external_connectors(self, user_input: dict[str, Any] | None = None):
@@ -560,7 +733,7 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
             step_id="external_connectors",
             data_schema=_external_connectors_schema(self.config_entry.data),
             errors=errors,
-            description_placeholders={"step": "5", "total_steps": "6"},
+            description_placeholders={"step": "7", "total_steps": "8"},
         )
 
     async def async_step_dashboard(self, user_input: dict[str, Any] | None = None):
@@ -568,6 +741,7 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
         if user_input is not None:
             updated_data = _merge_entry_data(
                 self.config_entry.data,
+                self.mode_info,
                 self.charger_info,
                 self.sensor_info,
                 self.pv_forecast_info,
@@ -585,7 +759,7 @@ class EVSCOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
         return self.async_show_form(
             step_id="dashboard",
             data_schema=_dashboard_schema(self.config_entry.data),
-            description_placeholders={"step": "6", "total_steps": "6"},
+            description_placeholders={"step": "8", "total_steps": "8"},
         )
 
     def _get_mobile_notify_services(self) -> list[str]:

--- a/custom_components/ev_smart_charger/const.py
+++ b/custom_components/ev_smart_charger/const.py
@@ -2,7 +2,7 @@
 
 # ========== INTEGRATION METADATA ==========
 DOMAIN = "ev_smart_charger"
-VERSION = "1.11.15"
+VERSION = "2.0.0"
 DEFAULT_NAME = "EV Smart Charger"
 FRONTEND_URL_BASE = "/api/ev_smart_charger/frontend"
 FRONTEND_CARD_FILENAME = "ev-smart-charger-dashboard.js"
@@ -60,8 +60,26 @@ LEGACY_CHARGING_PROFILES = [
 ]
 
 # ========== CHARGER AMPERAGE LEVELS ==========
-CHARGER_AMP_LEVELS = [6, 8, 10, 13, 16, 20, 24, 32]
-VOLTAGE_EU = 230  # European standard voltage
+CHARGER_AMP_LEVELS = [6, 8, 10, 13, 16, 20, 24, 32]  # Tuya-style discrete levels
+# Generic (non-Tuya) wallboxes accept any integer amperage → 1 A steps (v2.0.0)
+GENERIC_AMP_LEVELS = list(range(6, 33))  # [6, 7, 8, ..., 32]
+VOLTAGE_EU = 230  # European standard voltage (per phase)
+
+# ========== PHASE MODE & CHARGER MODEL (v2.0.0, opt-in) ==========
+# Phase mode: single-phase (default, unchanged behaviour) or three-phase.
+# In three-phase, production/consumption/grid are THREE sensors each (summed)
+# and the watt→amp conversion uses 3 × VOLTAGE_EU = 690 V, so per-phase amperage
+# thresholds and amp levels stay valid downstream.
+PHASE_MODE_SINGLE = "single"
+PHASE_MODE_THREE = "three"
+DEFAULT_PHASE_MODE = PHASE_MODE_SINGLE
+
+# Charger model: tuya (discrete CHARGER_AMP_LEVELS, safe stop/set/start on decrease,
+# default = current behaviour) or generic (1 A steps, live amperage decrease without
+# stopping the charger).
+CHARGER_MODEL_TUYA = "tuya"
+CHARGER_MODEL_GENERIC = "generic"
+DEFAULT_CHARGER_MODEL = CHARGER_MODEL_TUYA
 
 # ========== CONFIGURATION FLOW KEYS ==========
 CONF_EV_CHARGER_SWITCH = "ev_charger_switch"
@@ -73,6 +91,19 @@ CONF_FV_PRODUCTION = "fv_production"
 CONF_HOME_CONSUMPTION = "home_consumption"
 CONF_GRID_IMPORT = "grid_import"
 CONF_PV_FORECAST = "pv_forecast"
+
+# Phase mode + per-phase sensors (v2.0.0). The existing keys above act as L1
+# (so single-phase installs are byte-for-byte unchanged); L2/L3 are only mapped
+# and read when CONF_PHASE_MODE == PHASE_MODE_THREE. NOTE: only power quantities
+# are per-phase — soc_car / soc_home stay single (they are battery percentages).
+CONF_PHASE_MODE = "phase_mode"
+CONF_CHARGER_MODEL = "charger_model"
+CONF_FV_PRODUCTION_L2 = "fv_production_l2"
+CONF_FV_PRODUCTION_L3 = "fv_production_l3"
+CONF_HOME_CONSUMPTION_L2 = "home_consumption_l2"
+CONF_HOME_CONSUMPTION_L3 = "home_consumption_l3"
+CONF_GRID_IMPORT_L2 = "grid_import_l2"
+CONF_GRID_IMPORT_L3 = "grid_import_l3"
 # v1.11.14: distinct from CONF_PV_FORECAST. Optional sensor that reports
 # the *next-day* solar production forecast in kWh. Consumed only by the
 # auto-dashboard "Forecast Domani" chip — Night Smart Charge stays wired
@@ -312,6 +343,42 @@ TOTAL_INTEGRATION_ENTITIES_NO_BATTERY = 52
 def has_home_battery(config: dict) -> bool:
     """Return True if the user configured a home battery SOC sensor (v1.7.0)."""
     return bool(config.get(CONF_SOC_HOME))
+
+
+def is_three_phase(config: dict) -> bool:
+    """Return True if the install is configured as three-phase (v2.0.0)."""
+    return config.get(CONF_PHASE_MODE, DEFAULT_PHASE_MODE) == PHASE_MODE_THREE
+
+
+def get_phase_count(config: dict) -> int:
+    """Return the number of phases (1 single, 3 three-phase) (v2.0.0)."""
+    return 3 if is_three_phase(config) else 1
+
+
+def get_effective_voltage(config: dict) -> float:
+    """Return the watt→amp conversion voltage (phase_count × VOLTAGE_EU).
+
+    Single-phase → 230 V (unchanged). Three-phase → 690 V, so that
+    ``surplus_watts / effective_voltage`` yields the per-phase amperage a
+    balanced three-phase charger can sustain (P = 3 · V · I).
+    """
+    return get_phase_count(config) * VOLTAGE_EU
+
+
+def get_charger_model(config: dict) -> str:
+    """Return the configured charger model (v2.0.0)."""
+    return config.get(CONF_CHARGER_MODEL, DEFAULT_CHARGER_MODEL)
+
+
+def get_amp_levels(config: dict) -> list[int]:
+    """Return the amperage level set for the configured charger model (v2.0.0).
+
+    ``tuya`` → discrete CHARGER_AMP_LEVELS (default, unchanged).
+    ``generic`` → GENERIC_AMP_LEVELS (1 A steps, 6–32 A).
+    """
+    if get_charger_model(config) == CHARGER_MODEL_GENERIC:
+        return GENERIC_AMP_LEVELS
+    return CHARGER_AMP_LEVELS
 
 # ========== ANONYMOUS TELEMETRY ==========
 # Google Apps Script Web App endpoint (insert-only, no personal data).

--- a/custom_components/ev_smart_charger/dashboard_manager.py
+++ b/custom_components/ev_smart_charger/dashboard_manager.py
@@ -57,8 +57,14 @@ from .const import (
     CONF_EV_CHARGER_STATUS,
     CONF_EV_CHARGER_SWITCH,
     CONF_FV_PRODUCTION,
+    CONF_FV_PRODUCTION_L2,
+    CONF_FV_PRODUCTION_L3,
     CONF_GRID_IMPORT,
+    CONF_GRID_IMPORT_L2,
+    CONF_GRID_IMPORT_L3,
     CONF_HOME_CONSUMPTION,
+    CONF_HOME_CONSUMPTION_L2,
+    CONF_HOME_CONSUMPTION_L3,
     CONF_PV_FORECAST,
     CONF_PV_FORECAST_TOMORROW,
     CONF_SOC_CAR,
@@ -69,7 +75,11 @@ from .const import (
     DOMAIN,
     FRONTEND_CARD_FILENAME,
     FRONTEND_URL_BASE,
+    PHASE_MODE_SINGLE,
+    PHASE_MODE_THREE,
     VERSION,
+    get_charger_model,
+    is_three_phase,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -222,6 +232,21 @@ def _build_card_config(entry: ConfigEntry) -> dict[str, Any]:
         value = data.get(conf_key)
         if value:
             config[card_key] = value
+
+    # v2.0.0: phase mode + charger model. In three-phase, pass the per-phase
+    # entity lists so the card sums them for the power tiles (and uses 690 V for
+    # the derived charging-power reading). Single-phase keeps the single keys.
+    config["phase_mode"] = PHASE_MODE_THREE if is_three_phase(data) else PHASE_MODE_SINGLE
+    config["charger_model"] = get_charger_model(data)
+    if is_three_phase(data):
+        for card_key, conf_keys in (
+            ("solar_power_entities", (CONF_FV_PRODUCTION, CONF_FV_PRODUCTION_L2, CONF_FV_PRODUCTION_L3)),
+            ("home_consumption_entities", (CONF_HOME_CONSUMPTION, CONF_HOME_CONSUMPTION_L2, CONF_HOME_CONSUMPTION_L3)),
+            ("grid_import_entities", (CONF_GRID_IMPORT, CONF_GRID_IMPORT_L2, CONF_GRID_IMPORT_L3)),
+        ):
+            entities = [data[k] for k in conf_keys if data.get(k)]
+            if entities:
+                config[card_key] = entities
 
     return config
 

--- a/custom_components/ev_smart_charger/frontend/ev-smart-charger-dashboard.js
+++ b/custom_components/ev_smart_charger/frontend/ev-smart-charger-dashboard.js
@@ -196,7 +196,7 @@ const SETTINGS_CATALOG = [
           it: "Tetto massimo di corrente che Solar Surplus puo richiedere. Limita l'uso del wallbox al di sotto della portata fisica.",
           nl: "Maximale stroom die Solar Surplus mag opvragen. Beperkt wallboxgebruik onder de fysieke limiet.",
         },
-        hint: { en: "Default 32 A · Levels 6/8/10/13/16/20/24/32", it: "Default 32 A · Livelli 6/8/10/13/16/20/24/32", nl: "Standaard 32 A · Niveaus 6/8/10/13/16/20/24/32" } },
+        hint: { en: "Default 32 A · Tuya: 6/8/10/13/16/20/24/32 · Generic: 6–32 A (1 A)", it: "Default 32 A · Tuya: 6/8/10/13/16/20/24/32 · Generica: 6–32 A (1 A)", nl: "Standaard 32 A · Tuya: 6/8/10/13/16/20/24/32 · Generiek: 6–32 A (1 A)" } },
     ],
   },
   {
@@ -512,6 +512,7 @@ const FRONTEND_LOCALES = {
     "hero.banner.force_charging": "Force Charging Active",
     "hero.banner.boost_session": "Boost Session Active",
     "hero.banner.night_charge": "Night Smart Charge Active",
+    "hero.banner.charging": "EV Charging",
     "hero.forecast_tomorrow": "Tomorrow Forecast",
     "toast.boost.target_reached": "Boost can't start: EV at {ev}% (≥ target {target}%). Raise the target or wait for the battery to drain.",
     "toast.boost.missing_soc": "Boost can't start: EV SOC sensor unavailable. Check the mapped sensor.",
@@ -658,6 +659,7 @@ const FRONTEND_LOCALES = {
     "hero.banner.force_charging": "Force Charging in corso",
     "hero.banner.boost_session": "Boost Session in corso",
     "hero.banner.night_charge": "Night Smart Charge in corso",
+    "hero.banner.charging": "EV in ricarica",
     "hero.forecast_tomorrow": "Forecast Domani",
     "toast.boost.target_reached": "Boost non può partire: EV al {ev}% (≥ target {target}%). Alza il target o aspetta che la batteria scenda.",
     "toast.boost.missing_soc": "Boost non può partire: sensore SOC EV non disponibile. Controlla la mappatura.",
@@ -804,6 +806,7 @@ const FRONTEND_LOCALES = {
     "hero.banner.force_charging": "Force Charging actief",
     "hero.banner.boost_session": "Boost Sessie actief",
     "hero.banner.night_charge": "Slim nachtelijk laden actief",
+    "hero.banner.charging": "EV aan het laden",
     "hero.forecast_tomorrow": "Verwachting morgen",
     "toast.boost.target_reached": "Boost kan niet starten: EV op {ev}% (≥ doel {target}%). Verhoog het doel of wacht tot de batterij zakt.",
     "toast.boost.missing_soc": "Boost kan niet starten: EV SOC-sensor niet beschikbaar. Controleer de mapping.",
@@ -978,6 +981,16 @@ class EvSmartChargerDashboard extends HTMLElement {
       // proper next-day sensor without disturbing their existing
       // overnight-charge logic.
       pv_forecast_tomorrow_entity: config?.pv_forecast_tomorrow_entity,
+      // v2.0.0: phase mode + charger model. In three-phase the *_entities
+      // arrays carry the per-phase sensors so the power tiles can sum them;
+      // phase_mode drives the 230 V vs 690 V charging-power derivation.
+      // MUST be whitelisted here or they are silently dropped (cf. the
+      // v1.11.13 pv_forecast_entity regression above).
+      phase_mode: config?.phase_mode,
+      charger_model: config?.charger_model,
+      solar_power_entities: config?.solar_power_entities,
+      home_consumption_entities: config?.home_consumption_entities,
+      grid_import_entities: config?.grid_import_entities,
     };
 
     // v1.11.4: capture the build version injected by dashboard_manager.py.
@@ -1483,8 +1496,57 @@ class EvSmartChargerDashboard extends HTMLElement {
       );
       return null;
     }
-    const kw = (amps * VOLTAGE_EU) / 1000;
+    // v2.0.0: three-phase chargers draw on all phases → P = amps × 3 × 230.
+    const kw = (amps * this._effectiveVoltage()) / 1000;
     return Math.round(kw * 10) / 10;
+  }
+
+  /**
+   * v2.0.0: per-phase conversion voltage. Single-phase = 230 V, three-phase =
+   * 690 V (3 × 230). Used for the derived charging-power reading so a 16 A/phase
+   * session reads ~11 kW instead of ~3.7 kW.
+   */
+  _effectiveVoltage() {
+    return this._config.phase_mode === "three" ? VOLTAGE_EU * 3 : VOLTAGE_EU;
+  }
+
+  /**
+   * v2.0.0: sum the numeric states of a list of per-phase power sensors.
+   * Strict: returns null if ANY phase is unreadable — a partial sum would
+   * silently misreport the total (e.g. show 4 kW when one of three 2 kW phases
+   * dropped), so we surface "unavailable" instead.
+   */
+  _sumEntities(ids) {
+    if (!Array.isArray(ids) || ids.length === 0) return null;
+    let total = 0;
+    for (const id of ids) {
+      const v = this._numericState(id);
+      if (v == null) return null; // any unreadable phase → no reliable total
+      total += v;
+    }
+    return total;
+  }
+
+  /**
+   * v2.0.0: format a power quantity (solar / grid) honouring three-phase mode.
+   * When the per-phase `*_entities` array is present the phases are summed
+   * (all-or-nothing) and formatted — unit taken from the first phase that
+   * reports one (default "W"), value kept to 1 decimal so kW sensors don't
+   * lose precision. Otherwise the single-entity `_displayValue` path is used,
+   * so single-phase installs render exactly as before.
+   */
+  _phaseAwareDisplay(entitiesKey, singleKey, fallback) {
+    const ids = this._config[entitiesKey];
+    if (Array.isArray(ids) && ids.length > 0) {
+      const summed = this._sumEntities(ids);
+      if (summed == null) return fallback || this._t("common.unavailable");
+      const unit =
+        ids
+          .map((id) => this._stateObj(id)?.attributes?.unit_of_measurement)
+          .find((u) => u) || "W";
+      return `${Math.round(summed * 10) / 10} ${unit}`;
+    }
+    return this._displayValue(this._config[singleKey], fallback);
   }
 
   /**
@@ -2263,16 +2325,30 @@ class EvSmartChargerDashboard extends HTMLElement {
     const boostOn = this._isOn(ids.boostEnabledId);
     const nightSessionState = this._stateObj(ids.nightSessionId)?.state;
     const nightOn = nightSessionState === "battery" || nightSessionState === "grid";
+    // v1.11.16: generic "EV charging" green banner. Lowest precedence — only
+    // shown when none of Force / Boost / Night is active, so the more
+    // specific banners aren't hidden by the generic one. Derived from the
+    // mapped charger_status_entity ("charger_charging") OR a positive
+    // reading on the charging_power_entity, mirroring _renderHeroRing().
+    const chargerStatusForBanner = this._stateObj(this._config.charger_status_entity)?.state;
+    const chargingPowerObjForBanner = this._stateObj(this._config.charging_power_entity);
+    const chargingOn =
+      chargerStatusForBanner === "charger_charging" ||
+      (chargingPowerObjForBanner && Number(chargingPowerObjForBanner.state) > 0.05);
     const heroState = forceChargeOn
       ? "force"
       : (boostOn
         ? "boost"
-        : (nightOn ? "night" : "normal"));
+        : (nightOn
+          ? "night"
+          : (chargingOn ? "charging" : "normal")));
     const heroBannerKey = heroState === "force"
       ? "hero.banner.force_charging"
       : (heroState === "boost"
         ? "hero.banner.boost_session"
-        : "hero.banner.night_charge");
+        : (heroState === "night"
+          ? "hero.banner.night_charge"
+          : "hero.banner.charging"));
     const heroBanner = heroState === "normal"
       ? ""
       : `
@@ -2443,8 +2519,10 @@ class EvSmartChargerDashboard extends HTMLElement {
       this._config.home_battery_soc_entity,
       this._t("fallback.home_battery_soc_entity"),
     );
-    const solarPower = this._displayValue(this._config.solar_power_entity, this._t("fallback.solar_power_entity"));
-    const gridImport = this._displayValue(this._config.grid_import_entity, this._t("fallback.grid_import_entity"));
+    // v2.0.0: sum the per-phase sensors in three-phase mode (single-phase
+    // falls through to the original single-entity display path).
+    const solarPower = this._phaseAwareDisplay("solar_power_entities", "solar_power_entity", this._t("fallback.solar_power_entity"));
+    const gridImport = this._phaseAwareDisplay("grid_import_entities", "grid_import_entity", this._t("fallback.grid_import_entity"));
     const chargerCurrent = this._displayValue(this._config.current_entity, this._t("fallback.current_entity"));
 
     // v1.10.0: dispatch into Dashboard or Settings view depending on _view.
@@ -2548,6 +2626,19 @@ class EvSmartChargerDashboard extends HTMLElement {
     // the wrapper class flips, so the fast path can't patch it.
     const nightSessionState = states[this._entityId("nightSession")]?.state;
     const nightOn = nightSessionState === "battery" || nightSessionState === "grid";
+    // v1.11.16: generic charging banner is structural too — flipping
+    // between charging/normal swaps the banner DOM + wrapper class, which
+    // the fast path can't patch. We collapse the boolean derivation into
+    // the key so any transition (status flip or power crossing 0.05 kW)
+    // triggers exactly one full rebuild. Already covered transitively by
+    // `cs` for status changes, but include the derived value explicitly so
+    // a power-only signal (no status entity mapped) also rebuilds.
+    const chargingPowerStateForKey = this._config.charging_power_entity
+      ? Number(states[this._config.charging_power_entity]?.state)
+      : NaN;
+    const chargingOnForKey =
+      chargerStatus === "charger_charging" ||
+      (Number.isFinite(chargingPowerStateForKey) && chargingPowerStateForKey > 0.05);
 
     return JSON.stringify({
       view: this._view,
@@ -2561,6 +2652,7 @@ class EvSmartChargerDashboard extends HTMLElement {
       fc: forceChargeOn,
       bo: boostOn,
       ni: nightOn,
+      ch: chargingOnForKey,
     });
   }
 
@@ -3944,6 +4036,20 @@ class EvSmartChargerDashboard extends HTMLElement {
             var(--evsc-shadow-soft);
           animation: evsc-hero-border-pulse 2.2s ease-in-out infinite;
         }
+        /* v1.11.16: Generic "EV charging" live state. Uses Apple system green
+           — the universal "in progress, healthy" signal. Lowest precedence
+           after Force / Boost / Night so the more specific banners always
+           win when they're active. Same border-pulse cadence keeps the
+           four states visually consistent. */
+        .evsc-hero-state-charging {
+          --evsc-hero-accent: var(--evsc-sys-green);
+          --evsc-hero-glow: color-mix(in srgb, var(--evsc-sys-green) 45%, transparent);
+          box-shadow:
+            0 0 0 2px var(--evsc-hero-accent),
+            0 0 24px 4px var(--evsc-hero-glow),
+            var(--evsc-shadow-soft);
+          animation: evsc-hero-border-pulse 2.2s ease-in-out infinite;
+        }
         @keyframes evsc-hero-border-pulse {
           0%, 100% {
             box-shadow:
@@ -3973,6 +4079,7 @@ class EvSmartChargerDashboard extends HTMLElement {
         .evsc-hero-banner.banner-force { background: var(--evsc-sys-red); }
         .evsc-hero-banner.banner-boost { background: var(--evsc-deep-orange); }
         .evsc-hero-banner.banner-night { background: var(--evsc-sys-indigo); }
+        .evsc-hero-banner.banner-charging { background: var(--evsc-sys-green); }
         .evsc-hero-banner-dot {
           width: 8px;
           height: 8px;
@@ -3988,7 +4095,8 @@ class EvSmartChargerDashboard extends HTMLElement {
         @media (prefers-reduced-motion: reduce) {
           .evsc-hero-state-force,
           .evsc-hero-state-boost,
-          .evsc-hero-state-night { animation: none; }
+          .evsc-hero-state-night,
+          .evsc-hero-state-charging { animation: none; }
           .evsc-hero-banner-dot { animation: none; }
         }
 

--- a/custom_components/ev_smart_charger/hybrid_inverter_mode.py
+++ b/custom_components/ev_smart_charger/hybrid_inverter_mode.py
@@ -101,6 +101,7 @@ from .const import (
     PRIORITY_HOME,
     SURPLUS_STOP_THRESHOLD,
 )
+from .power_model import ChargingModel
 from .runtime import EVSCRuntimeData
 from .utils.amperage_helper import AmperageCalculator
 from .utils.astral_time_service import AstralTimeService
@@ -144,6 +145,17 @@ class HybridInverterMode:
         self._grid_import = config.get(CONF_GRID_IMPORT)
         self._soc_home = config.get(CONF_SOC_HOME)
         self._charger_status = config.get(CONF_EV_CHARGER_STATUS)
+
+        # v2.0.0: phase model. Levels follow the charger model; the negative-surplus
+        # floor scales with phase count (the 6 A probe draws phase_count× the power).
+        _pm = runtime_data.power_model if runtime_data is not None else None
+        self._power_model = (
+            _pm if isinstance(_pm, ChargingModel) else ChargingModel.from_config(config)
+        )
+        self._amp_levels = self._power_model.amp_levels
+        self._max_negative_surplus_w = (
+            HYBRID_MAX_NEGATIVE_SURPLUS_W * self._power_model.phase_count
+        )
 
         # Helper entities resolved in async_setup()
         self._enabled_entity: str | None = None
@@ -349,7 +361,7 @@ class HybridInverterMode:
 
         # 6A floor protection: if the house consumes much more than PV ceiling,
         # there is no plausible headroom even with curtailment.
-        if surplus_watts < HYBRID_MAX_NEGATIVE_SURPLUS_W:
+        if surplus_watts < self._max_negative_surplus_w:
             self._grid_import_below_threshold_since = None
             return False
 
@@ -537,8 +549,8 @@ class HybridInverterMode:
             return f"charger status now {status}"
 
         # 6A floor + plausibility
-        if surplus_watts < HYBRID_MAX_NEGATIVE_SURPLUS_W:
-            return f"surplus dropped below {HYBRID_MAX_NEGATIVE_SURPLUS_W}W (no plausible headroom)"
+        if surplus_watts < self._max_negative_surplus_w:
+            return f"surplus dropped below {self._max_negative_surplus_w}W (no plausible headroom)"
 
         # PRIORITY checks
         if priority == PRIORITY_HOME:
@@ -703,7 +715,7 @@ class HybridInverterMode:
                 self._import_violation_since = now
             violation_elapsed = (now - self._import_violation_since).total_seconds()
             if violation_elapsed >= max_import_duration:
-                next_down = AmperageCalculator.get_next_level_down(current_amps)
+                next_down = AmperageCalculator.get_next_level_down(current_amps, self._amp_levels)
                 if next_down >= 6:
                     self.logger.info(
                         f"{self.logger.ACTION} RIDING_EDGE: grid {grid_import:.0f}W "
@@ -748,7 +760,7 @@ class HybridInverterMode:
                 and current_amps < solar_max_amperage
             ):
                 next_up = AmperageCalculator.get_next_level_up(
-                    current_amps, solar_max_amperage
+                    current_amps, solar_max_amperage, self._amp_levels
                 )
                 if next_up > current_amps:
                     self.logger.info(

--- a/custom_components/ev_smart_charger/manifest.json
+++ b/custom_components/ev_smart_charger/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/antbald/ha-ev-smart-charger/issues",
   "requirements": [],
-  "version": "1.11.15"
+  "version": "2.0.0"
 }

--- a/custom_components/ev_smart_charger/night_smart_charge.py
+++ b/custom_components/ev_smart_charger/night_smart_charge.py
@@ -52,6 +52,7 @@ from .const import (
     has_home_battery,
 )
 from .localization import translate_runtime
+from .power_model import ChargingModel
 from .runtime import EVSCRuntimeData
 from .charger_controller import CurrentControlAdapter
 from .utils.logging_helper import EVSCLogger
@@ -122,6 +123,13 @@ class NightSmartCharge:
         self._grid_import = config.get(CONF_GRID_IMPORT)  # v1.3.23: Grid import sensor
         # v1.7.0: PV-only mode (no home battery configured)
         self._has_home_battery = has_home_battery(config)
+
+        # v2.0.0: phase-aware grid-import reader (sums L1/L2/L3 in three-phase).
+        # Single source = runtime power_model; fall back to building from config.
+        _pm = runtime_data.power_model if runtime_data is not None else None
+        self._power_model = (
+            _pm if isinstance(_pm, ChargingModel) else ChargingModel.from_config(config)
+        )
 
         # Helper entities (discovered in async_setup)
         self._night_charge_enabled_entity = None
@@ -1695,8 +1703,8 @@ class NightSmartCharge:
         grid_threshold = self._get_grid_import_threshold()
         grid_delay = self._get_grid_import_delay()
 
-        # Read grid import
-        grid_import = state_helper.get_float(self.hass, self._grid_import, default=0.0)
+        # Read grid import (v2.0.0: sums all phases in three-phase mode)
+        grid_import = self._power_model.read_grid_import(self.hass)
 
         self.logger.info(f"{self.logger.CHARGER} Dynamic amperage check:")
         self.logger.info(f"   Current: {current_amps}A, Target: {target_amps}A")

--- a/custom_components/ev_smart_charger/number.py
+++ b/custom_components/ev_smart_charger/number.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     has_home_battery,
+    get_charger_model,
+    CHARGER_MODEL_GENERIC,
     DEFAULT_CHECK_INTERVAL,
     DEFAULT_GRID_IMPORT_THRESHOLD,
     DEFAULT_GRID_IMPORT_DELAY,
@@ -85,6 +87,15 @@ async def async_setup_entry(
     }
     if not battery_configured:
         _NUMBER_DEFS = [d for d in _NUMBER_DEFS if d[0] not in _BATTERY_ONLY_NUMBERS]
+
+    # v2.0.0: generic (non-Tuya) wallboxes support 1 A steps. Amperage number
+    # entities (unit "A") then use step=1 so the UI lets users pick 7/11/… A.
+    # Tuya keeps step=2. Min/max (6–32) unchanged.
+    if get_charger_model(entry.data) == CHARGER_MODEL_GENERIC:
+        _NUMBER_DEFS = [
+            (suf, name, icon, mn, mx, (1 if u == "A" else st), dv, u)
+            for (suf, name, icon, mn, mx, st, dv, u) in _NUMBER_DEFS
+        ]
 
     entities = [
         EVSCNumber(

--- a/custom_components/ev_smart_charger/power_model.py
+++ b/custom_components/ev_smart_charger/power_model.py
@@ -1,0 +1,130 @@
+"""Charging power model: single source of truth for phase mode + charger model.
+
+Built once from the config entry data and stored on ``EVSCRuntimeData.power_model``
+(see ``__init__.py``). Encapsulates the only two things three-phase / charger-model
+support changes in the charging logic:
+
+- the watt→amp conversion voltage (``effective_voltage`` = phase_count × 230 V), and
+- the amperage level set (``amp_levels``: discrete Tuya levels vs 1 A generic steps).
+
+Single-phase + Tuya (the defaults) reproduce the pre-v2.0.0 behaviour exactly:
+``effective_voltage`` = 230, ``amp_levels`` = CHARGER_AMP_LEVELS, and the power
+readers return the single configured sensor value.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_FV_PRODUCTION,
+    CONF_FV_PRODUCTION_L2,
+    CONF_FV_PRODUCTION_L3,
+    CONF_GRID_IMPORT,
+    CONF_GRID_IMPORT_L2,
+    CONF_GRID_IMPORT_L3,
+    CONF_HOME_CONSUMPTION,
+    CONF_HOME_CONSUMPTION_L2,
+    CONF_HOME_CONSUMPTION_L3,
+    get_amp_levels,
+    get_charger_model,
+    get_effective_voltage,
+    get_phase_count,
+    is_three_phase,
+)
+from .utils.state_helper import get_float
+
+# Per-quantity config keys, ordered L1, L2, L3. L1 reuses the existing single-phase
+# key so single-phase installs read exactly the same entity as before.
+_PRODUCTION_KEYS = (CONF_FV_PRODUCTION, CONF_FV_PRODUCTION_L2, CONF_FV_PRODUCTION_L3)
+_CONSUMPTION_KEYS = (CONF_HOME_CONSUMPTION, CONF_HOME_CONSUMPTION_L2, CONF_HOME_CONSUMPTION_L3)
+_GRID_IMPORT_KEYS = (CONF_GRID_IMPORT, CONF_GRID_IMPORT_L2, CONF_GRID_IMPORT_L3)
+
+
+def _entities_for(config: dict, keys: tuple[str, ...]) -> list[str]:
+    """Return the configured entity ids for a quantity.
+
+    Single-phase → only L1 (``keys[0]``). Three-phase → L1/L2/L3, skipping any
+    that are not mapped (defensive; the config flow makes L2/L3 required in
+    three-phase, but a hand-edited entry might omit one).
+    """
+    if not is_three_phase(config):
+        entity = config.get(keys[0])
+        return [entity] if entity else []
+    return [config[k] for k in keys if config.get(k)]
+
+
+@dataclass
+class ChargingModel:
+    """Immutable view of phase mode + charger model derived from config."""
+
+    phase_count: int
+    effective_voltage: float
+    amp_levels: list[int]
+    charger_model: str
+    _production_entities: list[str]
+    _consumption_entities: list[str]
+    _grid_import_entities: list[str]
+
+    @classmethod
+    def from_config(cls, config: dict) -> "ChargingModel":
+        """Build the model from config entry data."""
+        return cls(
+            phase_count=get_phase_count(config),
+            effective_voltage=get_effective_voltage(config),
+            amp_levels=get_amp_levels(config),
+            charger_model=get_charger_model(config),
+            _production_entities=_entities_for(config, _PRODUCTION_KEYS),
+            _consumption_entities=_entities_for(config, _CONSUMPTION_KEYS),
+            _grid_import_entities=_entities_for(config, _GRID_IMPORT_KEYS),
+        )
+
+    # ----- entity lists (for validation / dashboard) -----
+    def production_entities(self) -> list[str]:
+        """Return mapped production sensors ([L1] or [L1, L2, L3])."""
+        return list(self._production_entities)
+
+    def consumption_entities(self) -> list[str]:
+        """Return mapped home-consumption sensors."""
+        return list(self._consumption_entities)
+
+    def grid_import_entities(self) -> list[str]:
+        """Return mapped grid-import sensors."""
+        return list(self._grid_import_entities)
+
+    def labelled_power_entities(self) -> list[tuple[str, str]]:
+        """Return (entity_id, label) pairs for all power sensors, for validation.
+
+        Labels gain an "Ln" suffix only in three-phase so single-phase log
+        messages are unchanged.
+        """
+        out: list[tuple[str, str]] = []
+        groups = (
+            ("Solar Production", self._production_entities),
+            ("Home Consumption", self._consumption_entities),
+            ("Grid Import", self._grid_import_entities),
+        )
+        for base, entities in groups:
+            for idx, entity in enumerate(entities):
+                label = base if self.phase_count == 1 else f"{base} L{idx + 1}"
+                out.append((entity, label))
+        return out
+
+    # ----- power readers (sum across phases) -----
+    def read_production(self, hass: HomeAssistant) -> float:
+        """Total PV production (W), summed across phases in three-phase mode."""
+        return sum(get_float(hass, e) for e in self._production_entities)
+
+    def read_consumption(self, hass: HomeAssistant) -> float:
+        """Total home consumption (W), summed across phases."""
+        return sum(get_float(hass, e) for e in self._consumption_entities)
+
+    def read_grid_import(self, hass: HomeAssistant) -> float:
+        """Total grid import (W, positive = importing), summed across phases."""
+        return sum(get_float(hass, e) for e in self._grid_import_entities)
+
+    # ----- conversion -----
+    def watts_to_amps(self, watts: float) -> float:
+        """Convert total watts to per-phase amperage using the effective voltage."""
+        return watts / self.effective_voltage

--- a/custom_components/ev_smart_charger/runtime.py
+++ b/custom_components/ev_smart_charger/runtime.py
@@ -29,6 +29,7 @@ class EVSCRuntimeData:
     hybrid_mode: Any | None = None  # Hybrid Inverter Mode (v1.8.0 — issue #20)
     log_manager: Any | None = None
     diagnostic_manager: Any | None = None
+    power_model: Any | None = None  # ChargingModel (phase mode + charger model, v2.0.0)
 
     def register_entity(self, key: str, entity_id: str, entity: Any) -> None:
         """Register an integration-owned entity."""

--- a/custom_components/ev_smart_charger/solar_surplus.py
+++ b/custom_components/ev_smart_charger/solar_surplus.py
@@ -9,9 +9,7 @@ from homeassistant.helpers.event import async_track_time_interval, async_track_s
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    CHARGER_AMP_LEVELS,
     CHARGER_STATUS_FREE,
-    VOLTAGE_EU,
     CONF_EV_CHARGER_STATUS,
     CONF_FV_PRODUCTION,
     CONF_HOME_CONSUMPTION,
@@ -35,6 +33,7 @@ from .const import (
     NIGHT_CHARGE_COOLDOWN_SECONDS,
     has_home_battery,
 )
+from .power_model import ChargingModel
 from .runtime import EVSCRuntimeData
 from .utils.logging_helper import EVSCLogger
 from .utils.state_helper import get_state, get_float, get_bool, validate_sensor
@@ -94,6 +93,16 @@ class SolarSurplusAutomation:
         self._soc_home = config.get(CONF_SOC_HOME)
         # v1.7.0: PV-only mode (no home battery configured)
         self._has_home_battery = has_home_battery(config)
+
+        # v2.0.0: phase mode + charger model. Single source = runtime power_model
+        # (built once in __init__.py); fall back to building from config so direct
+        # construction in tests still works. Single-phase + Tuya = unchanged values.
+        _pm = runtime_data.power_model if runtime_data is not None else None
+        self._power_model = (
+            _pm if isinstance(_pm, ChargingModel) else ChargingModel.from_config(config)
+        )
+        self._effective_voltage = self._power_model.effective_voltage
+        self._amp_levels = self._power_model.amp_levels
 
         # Helper entities (discovered during setup)
         self._forza_ricarica_entity = None
@@ -586,12 +595,11 @@ class SolarSurplusAutomation:
             self.logger.info("Priority Balancer disabled - using fallback mode")
 
         # === 9. Validate Sensors (with throttled logging to prevent spam) ===
+        # v2.0.0: validate EVERY mapped phase sensor (L1/L2/L3 in three-phase)
+        # BEFORE summing — a single unavailable phase would otherwise be read as
+        # 0 W by get_float and silently halve production/consumption.
         sensor_errors = []
-        sensors_to_validate = [
-            (self._fv_production, "Solar Production"),
-            (self._home_consumption, "Home Consumption"),
-            (self._grid_import, "Grid Import"),
-        ]
+        sensors_to_validate = self._power_model.labelled_power_entities()
 
         # Check each sensor and track error state changes
         new_errors = False
@@ -628,11 +636,14 @@ class SolarSurplusAutomation:
             return
 
         # === 10. Calculate Surplus ===
-        fv_production = get_float(self.hass, self._fv_production)
-        home_consumption = get_float(self.hass, self._home_consumption)
-        grid_import = get_float(self.hass, self._grid_import)
+        # v2.0.0: power readers sum across phases (single-phase = single sensor),
+        # and the watt→amp conversion uses the effective voltage (230 V single,
+        # 690 V three-phase) so surplus_amps stays a valid per-phase amperage.
+        fv_production = self._power_model.read_production(self.hass)
+        home_consumption = self._power_model.read_consumption(self.hass)
+        grid_import = self._power_model.read_grid_import(self.hass)
         surplus_watts = fv_production - home_consumption
-        surplus_amps = surplus_watts / VOLTAGE_EU
+        surplus_amps = surplus_watts / self._effective_voltage
 
         self.logger.info(f"Solar Production: {fv_production}W")
         self.logger.info(f"Home Consumption: {home_consumption}W")
@@ -687,13 +698,13 @@ class SolarSurplusAutomation:
         target_amps = self._calculate_target_amperage(surplus_watts, current_amps)
 
         # Apply user-configured maximum amperage cap (issue #11: wallboxes with <32A limit).
-        # Always cap to the highest valid CHARGER_AMP_LEVELS value that doesn't exceed max_amps
+        # Always cap to the highest valid amp level that doesn't exceed max_amps
         # to avoid sending non-standard amperages to the wallbox.
         if target_amps > 0:
             max_amps = int(get_float(self.hass, self._solar_max_amperage_entity, DEFAULT_SOLAR_MAX_AMPERAGE))
             if target_amps > max_amps:
-                valid_below_max = [l for l in CHARGER_AMP_LEVELS if l <= max_amps]
-                capped = valid_below_max[-1] if valid_below_max else CHARGER_AMP_LEVELS[0]
+                valid_below_max = [l for l in self._amp_levels if l <= max_amps]
+                capped = valid_below_max[-1] if valid_below_max else self._amp_levels[0]
                 self.logger.info(f"Target capped: {target_amps}A → {capped}A (solar max amperage: {max_amps}A)")
                 target_amps = capped
 
@@ -714,7 +725,7 @@ class SolarSurplusAutomation:
             else:
                 elapsed = (dt_util.now() - self._deadband_start_time).total_seconds()
                 if elapsed >= SURPLUS_DEADBAND_START_DELAY:
-                    target_amps = CHARGER_AMP_LEVELS[0]  # 6A minimum
+                    target_amps = self._amp_levels[0]  # 6A minimum
                     self.logger.info(
                         f"Dead band surplus persistent for {elapsed:.0f}s >= "
                         f"{SURPLUS_DEADBAND_START_DELAY}s - "
@@ -1155,14 +1166,15 @@ class SolarSurplusAutomation:
         - Stop threshold: 5.5A (SURPLUS_STOP_THRESHOLD)
         - Dead band: 5.5A - 6.5A (maintain current level, no changes)
         """
-        # ALWAYS calculate from surplus first
-        surplus_amps = surplus_watts / VOLTAGE_EU
+        # ALWAYS calculate from surplus first (effective voltage = 230 V single,
+        # 690 V three-phase → surplus_amps stays a valid per-phase amperage)
+        surplus_amps = surplus_watts / self._effective_voltage
         is_charging = current_amperage > 0
 
         # CASE 1: Surplus sufficient to START or INCREASE (>= 6.5A)
         if surplus_amps >= SURPLUS_START_THRESHOLD:
-            target = CHARGER_AMP_LEVELS[0]
-            for level in CHARGER_AMP_LEVELS:
+            target = self._amp_levels[0]
+            for level in self._amp_levels:
                 if level <= surplus_amps:
                     target = level
                 else:
@@ -1260,7 +1272,7 @@ class SolarSurplusAutomation:
         self._last_grid_import_high = None
 
         # Gradual ramp down: one level at a time via AmperageCalculator
-        next_amps = AmperageCalculator.get_next_level_down(current_amps)
+        next_amps = AmperageCalculator.get_next_level_down(current_amps, self._amp_levels)
 
         if next_amps > 0:
             self.logger.info(f"Stepping down ONE level: {current_amps}A -> {next_amps}A")
@@ -1307,7 +1319,7 @@ class SolarSurplusAutomation:
             # At minimum level or non-standard level — stop charger
             reason = (
                 "Grid import protection - minimum level reached"
-                if current_amps in CHARGER_AMP_LEVELS
+                if current_amps in self._amp_levels
                 else f"Grid import protection - non-standard level {current_amps}A"
             )
             self.logger.info(f"Stopping charger: {reason}")
@@ -1362,7 +1374,7 @@ class SolarSurplusAutomation:
         self._last_surplus_sufficient = None
 
         # Gradual ramp down: one level at a time via AmperageCalculator
-        next_amps = AmperageCalculator.get_next_level_down(current_amps)
+        next_amps = AmperageCalculator.get_next_level_down(current_amps, self._amp_levels)
 
         if next_amps > 0:
             self.logger.info(f"Stepping down ONE level: {current_amps}A -> {next_amps}A")

--- a/custom_components/ev_smart_charger/strings.json
+++ b/custom_components/ev_smart_charger/strings.json
@@ -27,20 +27,32 @@
       },
       "sensors": {
         "title": "Energy Sensors - Step {step}/{total_steps}",
-        "description": "Map the sensors used by Solar Surplus, Priority Balancer, and Night Smart Charge.",
+        "description": "Map the sensors used by Solar Surplus, Priority Balancer, and Night Smart Charge. In three-phase mode you map three sensors per quantity (one per phase).",
         "data": {
           "soc_car": "EV battery SOC",
           "soc_home": "Home battery SOC (optional)",
           "fv_production": "Solar production",
           "home_consumption": "Home consumption",
-          "grid_import": "Grid import"
+          "grid_import": "Grid import",
+          "fv_production_l2": "Solar production (L2)",
+          "fv_production_l3": "Solar production (L3)",
+          "home_consumption_l2": "Home consumption (L2)",
+          "home_consumption_l3": "Home consumption (L3)",
+          "grid_import_l2": "Grid import (L2)",
+          "grid_import_l3": "Grid import (L3)"
         },
         "data_description": {
           "soc_car": "Sensor with the EV state of charge in percent.",
           "soc_home": "Optional. Sensor with the home battery state of charge in percent. Leave empty if you do not have a home battery — the integration will run in PV-only mode. Once configured this field cannot be cleared (to prevent orphan helper entities); to remove a home battery, delete and re-add the integration.",
           "fv_production": "Sensor with current PV production in watts.",
           "home_consumption": "Sensor with current household consumption in watts, excluding EV charging when possible.",
-          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid."
+          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid.",
+          "fv_production_l2": "Solar production on phase L2, in watts.",
+          "fv_production_l3": "Solar production on phase L3, in watts.",
+          "home_consumption_l2": "Home consumption on phase L2, in watts.",
+          "home_consumption_l3": "Home consumption on phase L3, in watts.",
+          "grid_import_l2": "Grid import on phase L2, in watts.",
+          "grid_import_l3": "Grid import on phase L3, in watts."
         }
       },
       "pv_forecast": {
@@ -90,35 +102,43 @@
         }
       },
       "reconfigure": {
-        "title": "Reconfigure Charger Entities - Step {step}/{total_steps}",
-        "description": "Update the charger entities for this config entry.",
+        "title": "Reconfigure Phase Mode - Step {step}/{total_steps}",
+        "description": "Choose how your electrical system is wired.\n\n**Single-phase** — one phase (230 V, charging up to ~3.7 kW): you map one sensor each for solar production, home consumption and grid import, as before. This is the most common setup.\n\n**Three-phase** — three phases (230 V each, charging ~11–22 kW): you map three sensors each for production, consumption and grid import (one per phase); the integration sums them and balances the charging speed across all three phases. In three-phase every amperage setting means roughly 3× the power of single-phase (e.g. 16 A ≈ 11 kW) and the minimum is ~4.1 kW — make sure your battery inverter can sustain the chosen power.",
         "data": {
-          "ev_charger_switch": "Charger switch",
-          "ev_charger_current": "Charging current control",
-          "ev_charger_status": "Charger status sensor"
+          "phase_mode": "Electrical phases"
         },
         "data_description": {
-          "ev_charger_switch": "Switch entity that turns the charger on or off.",
-          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+          "phase_mode": "Single-phase is the default and matches most homes. Choose three-phase only if your installation is genuinely three-phase."
         }
       },
       "reconfigure_sensors": {
         "title": "Reconfigure Energy Sensors - Step {step}/{total_steps}",
-        "description": "Update the energy and SOC sensors used by the integration.",
+        "description": "Update the energy and SOC sensors used by the integration. In three-phase mode you map three sensors per quantity (one per phase).",
         "data": {
           "soc_car": "EV battery SOC",
           "soc_home": "Home battery SOC (optional)",
           "fv_production": "Solar production",
           "home_consumption": "Home consumption",
-          "grid_import": "Grid import"
+          "grid_import": "Grid import",
+          "fv_production_l2": "Solar production (L2)",
+          "fv_production_l3": "Solar production (L3)",
+          "home_consumption_l2": "Home consumption (L2)",
+          "home_consumption_l3": "Home consumption (L3)",
+          "grid_import_l2": "Grid import (L2)",
+          "grid_import_l3": "Grid import (L3)"
         },
         "data_description": {
           "soc_car": "Sensor with the EV state of charge in percent.",
           "soc_home": "Optional. Sensor with the home battery state of charge in percent. Leave empty if you do not have a home battery — the integration will run in PV-only mode. Once configured this field cannot be cleared (to prevent orphan helper entities); to remove a home battery, delete and re-add the integration.",
           "fv_production": "Sensor with current PV production in watts.",
           "home_consumption": "Sensor with current household consumption in watts, excluding EV charging when possible.",
-          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid."
+          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid.",
+          "fv_production_l2": "Solar production on phase L2, in watts.",
+          "fv_production_l3": "Solar production on phase L3, in watts.",
+          "home_consumption_l2": "Home consumption on phase L2, in watts.",
+          "home_consumption_l3": "Home consumption on phase L3, in watts.",
+          "grid_import_l2": "Grid import on phase L2, in watts.",
+          "grid_import_l3": "Grid import on phase L3, in watts."
         }
       },
       "reconfigure_pv_forecast": {
@@ -166,6 +186,50 @@
         "data_description": {
           "create_dashboard": "Toggle to create or remove the dedicated EV Smart Charger Lovelace dashboard."
         }
+      },
+      "reconfigure_entities": {
+        "title": "Reconfigure Charger Entities - Step {step}/{total_steps}",
+        "description": "Update the charger entities for this config entry.",
+        "data": {
+          "ev_charger_switch": "Charger switch",
+          "ev_charger_current": "Charging current control",
+          "ev_charger_status": "Charger status sensor"
+        },
+        "data_description": {
+          "ev_charger_switch": "Switch entity that turns the charger on or off.",
+          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+        }
+      },
+      "phase_mode": {
+        "title": "Phase Mode - Step {step}/{total_steps}",
+        "description": "Choose how your electrical system is wired.\n\n**Single-phase** — one phase (230 V, charging up to ~3.7 kW): you map one sensor each for solar production, home consumption and grid import, as before. This is the most common setup.\n\n**Three-phase** — three phases (230 V each, charging ~11–22 kW): you map three sensors each for production, consumption and grid import (one per phase); the integration sums them and balances the charging speed across all three phases. In three-phase every amperage setting means roughly 3× the power of single-phase (e.g. 16 A ≈ 11 kW) and the minimum is ~4.1 kW — make sure your battery inverter can sustain the chosen power.",
+        "data": {
+          "phase_mode": "Electrical phases"
+        },
+        "data_description": {
+          "phase_mode": "Single-phase is the default and matches most homes. Choose three-phase only if your installation is genuinely three-phase."
+        }
+      },
+      "charger_model": {
+        "title": "Wallbox Model - Step {step}/{total_steps}",
+        "description": "Choose how your wallbox adjusts the charging current.\n\n**Tuya** — current is set only to fixed values (6, 8, 10, 13, 16, 20, 24, 32 A); to lower it the wallbox is switched off and on (a few seconds' pause). This is the default and works with the most common wallboxes — pick it if unsure.\n\n**Generic** — accepts any whole-ampere value (6, 7, 8, … 32 A) via a `number` entity: finer control and, when decreasing, the current drops live without interrupting the session.",
+        "data": {
+          "charger_model": "Wallbox type"
+        },
+        "data_description": {
+          "charger_model": "Tuya = fixed steps (default). Generic = 1 A steps for non-Tuya wallboxes that expose the current as a number entity."
+        }
+      },
+      "reconfigure_charger_model": {
+        "title": "Reconfigure Wallbox Model - Step {step}/{total_steps}",
+        "description": "Choose how your wallbox adjusts the charging current.\n\n**Tuya** — current is set only to fixed values (6, 8, 10, 13, 16, 20, 24, 32 A); to lower it the wallbox is switched off and on (a few seconds' pause). This is the default and works with the most common wallboxes — pick it if unsure.\n\n**Generic** — accepts any whole-ampere value (6, 7, 8, … 32 A) via a `number` entity: finer control and, when decreasing, the current drops live without interrupting the session.",
+        "data": {
+          "charger_model": "Wallbox type"
+        },
+        "data_description": {
+          "charger_model": "Tuya = fixed steps (default). Generic = 1 A steps for non-Tuya wallboxes that expose the current as a number entity."
+        }
       }
     },
     "error": {
@@ -183,35 +247,43 @@
   "options": {
     "step": {
       "init": {
-        "title": "Update Charger Entities - Step {step}/{total_steps}",
-        "description": "Compatibility wrapper around the canonical reconfigure flow. Update the charger entities for this entry.",
+        "title": "Update Phase Mode - Step {step}/{total_steps}",
+        "description": "Choose how your electrical system is wired.\n\n**Single-phase** — one phase (230 V, charging up to ~3.7 kW): you map one sensor each for solar production, home consumption and grid import, as before. This is the most common setup.\n\n**Three-phase** — three phases (230 V each, charging ~11–22 kW): you map three sensors each for production, consumption and grid import (one per phase); the integration sums them and balances the charging speed across all three phases. In three-phase every amperage setting means roughly 3× the power of single-phase (e.g. 16 A ≈ 11 kW) and the minimum is ~4.1 kW — make sure your battery inverter can sustain the chosen power.",
         "data": {
-          "ev_charger_switch": "Charger switch",
-          "ev_charger_current": "Charging current control",
-          "ev_charger_status": "Charger status sensor"
+          "phase_mode": "Electrical phases"
         },
         "data_description": {
-          "ev_charger_switch": "Switch entity that turns the charger on or off.",
-          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+          "phase_mode": "Single-phase is the default and matches most homes. Choose three-phase only if your installation is genuinely three-phase."
         }
       },
       "sensors": {
         "title": "Update Energy Sensors - Step {step}/{total_steps}",
-        "description": "Update the energy and SOC sensors used by the integration.",
+        "description": "Update the energy and SOC sensors used by the integration. In three-phase mode you map three sensors per quantity (one per phase).",
         "data": {
           "soc_car": "EV battery SOC",
           "soc_home": "Home battery SOC (optional)",
           "fv_production": "Solar production",
           "home_consumption": "Home consumption",
-          "grid_import": "Grid import"
+          "grid_import": "Grid import",
+          "fv_production_l2": "Solar production (L2)",
+          "fv_production_l3": "Solar production (L3)",
+          "home_consumption_l2": "Home consumption (L2)",
+          "home_consumption_l3": "Home consumption (L3)",
+          "grid_import_l2": "Grid import (L2)",
+          "grid_import_l3": "Grid import (L3)"
         },
         "data_description": {
           "soc_car": "Sensor with the EV state of charge in percent.",
           "soc_home": "Optional. Sensor with the home battery state of charge in percent. Leave empty if you do not have a home battery — the integration will run in PV-only mode. Once configured this field cannot be cleared (to prevent orphan helper entities); to remove a home battery, delete and re-add the integration.",
           "fv_production": "Sensor with current PV production in watts.",
           "home_consumption": "Sensor with current household consumption in watts, excluding EV charging when possible.",
-          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid."
+          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid.",
+          "fv_production_l2": "Solar production on phase L2, in watts.",
+          "fv_production_l3": "Solar production on phase L3, in watts.",
+          "home_consumption_l2": "Home consumption on phase L2, in watts.",
+          "home_consumption_l3": "Home consumption on phase L3, in watts.",
+          "grid_import_l2": "Grid import on phase L2, in watts.",
+          "grid_import_l3": "Grid import on phase L3, in watts."
         }
       },
       "pv_forecast": {
@@ -258,6 +330,30 @@
         },
         "data_description": {
           "create_dashboard": "When enabled, a Lovelace dashboard preloaded with all integration entities is added to the sidebar at /ev-smart-charger."
+        }
+      },
+      "entities": {
+        "title": "Update Charger Entities - Step {step}/{total_steps}",
+        "description": "Compatibility wrapper around the canonical reconfigure flow. Update the charger entities for this entry.",
+        "data": {
+          "ev_charger_switch": "Charger switch",
+          "ev_charger_current": "Charging current control",
+          "ev_charger_status": "Charger status sensor"
+        },
+        "data_description": {
+          "ev_charger_switch": "Switch entity that turns the charger on or off.",
+          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+        }
+      },
+      "charger_model": {
+        "title": "Update Wallbox Model - Step {step}/{total_steps}",
+        "description": "Choose how your wallbox adjusts the charging current.\n\n**Tuya** — current is set only to fixed values (6, 8, 10, 13, 16, 20, 24, 32 A); to lower it the wallbox is switched off and on (a few seconds' pause). This is the default and works with the most common wallboxes — pick it if unsure.\n\n**Generic** — accepts any whole-ampere value (6, 7, 8, … 32 A) via a `number` entity: finer control and, when decreasing, the current drops live without interrupting the session.",
+        "data": {
+          "charger_model": "Wallbox type"
+        },
+        "data_description": {
+          "charger_model": "Tuya = fixed steps (default). Generic = 1 A steps for non-Tuya wallboxes that expose the current as a number entity."
         }
       }
     },
@@ -440,6 +536,20 @@
       },
       "evsc_car_ready_time": {
         "name": "Car ready time"
+      }
+    }
+  },
+  "selector": {
+    "phase_mode": {
+      "options": {
+        "single": "Single-phase",
+        "three": "Three-phase"
+      }
+    },
+    "charger_model": {
+      "options": {
+        "tuya": "Tuya (standard)",
+        "generic": "Generic (1 A steps)"
       }
     }
   }

--- a/custom_components/ev_smart_charger/translations/en.json
+++ b/custom_components/ev_smart_charger/translations/en.json
@@ -27,20 +27,32 @@
       },
       "sensors": {
         "title": "Energy Sensors - Step {step}/{total_steps}",
-        "description": "Map the sensors used by Solar Surplus, Priority Balancer, and Night Smart Charge.",
+        "description": "Map the sensors used by Solar Surplus, Priority Balancer, and Night Smart Charge. In three-phase mode you map three sensors per quantity (one per phase).",
         "data": {
           "soc_car": "EV battery SOC",
           "soc_home": "Home battery SOC",
           "fv_production": "Solar production",
           "home_consumption": "Home consumption",
-          "grid_import": "Grid import"
+          "grid_import": "Grid import",
+          "fv_production_l2": "Solar production (L2)",
+          "fv_production_l3": "Solar production (L3)",
+          "home_consumption_l2": "Home consumption (L2)",
+          "home_consumption_l3": "Home consumption (L3)",
+          "grid_import_l2": "Grid import (L2)",
+          "grid_import_l3": "Grid import (L3)"
         },
         "data_description": {
           "soc_car": "Sensor with the EV state of charge in percent.",
           "soc_home": "Sensor with the home battery state of charge in percent.",
           "fv_production": "Sensor with current PV production in watts.",
           "home_consumption": "Sensor with current household consumption in watts, excluding EV charging when possible.",
-          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid."
+          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid.",
+          "fv_production_l2": "Solar production on phase L2, in watts.",
+          "fv_production_l3": "Solar production on phase L3, in watts.",
+          "home_consumption_l2": "Home consumption on phase L2, in watts.",
+          "home_consumption_l3": "Home consumption on phase L3, in watts.",
+          "grid_import_l2": "Grid import on phase L2, in watts.",
+          "grid_import_l3": "Grid import on phase L3, in watts."
         }
       },
       "pv_forecast": {
@@ -90,35 +102,43 @@
         }
       },
       "reconfigure": {
-        "title": "Reconfigure Charger Entities - Step {step}/{total_steps}",
-        "description": "Update the charger entities for this config entry.",
+        "title": "Reconfigure Phase Mode - Step {step}/{total_steps}",
+        "description": "Choose how your electrical system is wired.\n\n**Single-phase** — one phase (230 V, charging up to ~3.7 kW): you map one sensor each for solar production, home consumption and grid import, as before. This is the most common setup.\n\n**Three-phase** — three phases (230 V each, charging ~11–22 kW): you map three sensors each for production, consumption and grid import (one per phase); the integration sums them and balances the charging speed across all three phases. In three-phase every amperage setting means roughly 3× the power of single-phase (e.g. 16 A ≈ 11 kW) and the minimum is ~4.1 kW — make sure your battery inverter can sustain the chosen power.",
         "data": {
-          "ev_charger_switch": "Charger switch",
-          "ev_charger_current": "Charging current control",
-          "ev_charger_status": "Charger status sensor"
+          "phase_mode": "Electrical phases"
         },
         "data_description": {
-          "ev_charger_switch": "Switch entity that turns the charger on or off.",
-          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+          "phase_mode": "Single-phase is the default and matches most homes. Choose three-phase only if your installation is genuinely three-phase."
         }
       },
       "reconfigure_sensors": {
         "title": "Reconfigure Energy Sensors - Step {step}/{total_steps}",
-        "description": "Update the energy and SOC sensors used by the integration.",
+        "description": "Update the energy and SOC sensors used by the integration. In three-phase mode you map three sensors per quantity (one per phase).",
         "data": {
           "soc_car": "EV battery SOC",
           "soc_home": "Home battery SOC",
           "fv_production": "Solar production",
           "home_consumption": "Home consumption",
-          "grid_import": "Grid import"
+          "grid_import": "Grid import",
+          "fv_production_l2": "Solar production (L2)",
+          "fv_production_l3": "Solar production (L3)",
+          "home_consumption_l2": "Home consumption (L2)",
+          "home_consumption_l3": "Home consumption (L3)",
+          "grid_import_l2": "Grid import (L2)",
+          "grid_import_l3": "Grid import (L3)"
         },
         "data_description": {
           "soc_car": "Sensor with the EV state of charge in percent.",
           "soc_home": "Sensor with the home battery state of charge in percent.",
           "fv_production": "Sensor with current PV production in watts.",
           "home_consumption": "Sensor with current household consumption in watts, excluding EV charging when possible.",
-          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid."
+          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid.",
+          "fv_production_l2": "Solar production on phase L2, in watts.",
+          "fv_production_l3": "Solar production on phase L3, in watts.",
+          "home_consumption_l2": "Home consumption on phase L2, in watts.",
+          "home_consumption_l3": "Home consumption on phase L3, in watts.",
+          "grid_import_l2": "Grid import on phase L2, in watts.",
+          "grid_import_l3": "Grid import on phase L3, in watts."
         }
       },
       "reconfigure_pv_forecast": {
@@ -166,6 +186,50 @@
         "data_description": {
           "create_dashboard": "Toggle to create or remove the EV Smart Charger Lovelace dashboard."
         }
+      },
+      "reconfigure_entities": {
+        "title": "Reconfigure Charger Entities - Step {step}/{total_steps}",
+        "description": "Update the charger entities for this config entry.",
+        "data": {
+          "ev_charger_switch": "Charger switch",
+          "ev_charger_current": "Charging current control",
+          "ev_charger_status": "Charger status sensor"
+        },
+        "data_description": {
+          "ev_charger_switch": "Switch entity that turns the charger on or off.",
+          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+        }
+      },
+      "phase_mode": {
+        "title": "Phase Mode - Step {step}/{total_steps}",
+        "description": "Choose how your electrical system is wired.\n\n**Single-phase** — one phase (230 V, charging up to ~3.7 kW): you map one sensor each for solar production, home consumption and grid import, as before. This is the most common setup.\n\n**Three-phase** — three phases (230 V each, charging ~11–22 kW): you map three sensors each for production, consumption and grid import (one per phase); the integration sums them and balances the charging speed across all three phases. In three-phase every amperage setting means roughly 3× the power of single-phase (e.g. 16 A ≈ 11 kW) and the minimum is ~4.1 kW — make sure your battery inverter can sustain the chosen power.",
+        "data": {
+          "phase_mode": "Electrical phases"
+        },
+        "data_description": {
+          "phase_mode": "Single-phase is the default and matches most homes. Choose three-phase only if your installation is genuinely three-phase."
+        }
+      },
+      "charger_model": {
+        "title": "Wallbox Model - Step {step}/{total_steps}",
+        "description": "Choose how your wallbox adjusts the charging current.\n\n**Tuya** — current is set only to fixed values (6, 8, 10, 13, 16, 20, 24, 32 A); to lower it the wallbox is switched off and on (a few seconds' pause). This is the default and works with the most common wallboxes — pick it if unsure.\n\n**Generic** — accepts any whole-ampere value (6, 7, 8, … 32 A) via a `number` entity: finer control and, when decreasing, the current drops live without interrupting the session.",
+        "data": {
+          "charger_model": "Wallbox type"
+        },
+        "data_description": {
+          "charger_model": "Tuya = fixed steps (default). Generic = 1 A steps for non-Tuya wallboxes that expose the current as a number entity."
+        }
+      },
+      "reconfigure_charger_model": {
+        "title": "Reconfigure Wallbox Model - Step {step}/{total_steps}",
+        "description": "Choose how your wallbox adjusts the charging current.\n\n**Tuya** — current is set only to fixed values (6, 8, 10, 13, 16, 20, 24, 32 A); to lower it the wallbox is switched off and on (a few seconds' pause). This is the default and works with the most common wallboxes — pick it if unsure.\n\n**Generic** — accepts any whole-ampere value (6, 7, 8, … 32 A) via a `number` entity: finer control and, when decreasing, the current drops live without interrupting the session.",
+        "data": {
+          "charger_model": "Wallbox type"
+        },
+        "data_description": {
+          "charger_model": "Tuya = fixed steps (default). Generic = 1 A steps for non-Tuya wallboxes that expose the current as a number entity."
+        }
       }
     },
     "error": {
@@ -183,35 +247,43 @@
   "options": {
     "step": {
       "init": {
-        "title": "Update Charger Entities - Step {step}/{total_steps}",
-        "description": "Compatibility wrapper around the canonical reconfigure flow. Update the charger entities for this entry.",
+        "title": "Update Phase Mode - Step {step}/{total_steps}",
+        "description": "Choose how your electrical system is wired.\n\n**Single-phase** — one phase (230 V, charging up to ~3.7 kW): you map one sensor each for solar production, home consumption and grid import, as before. This is the most common setup.\n\n**Three-phase** — three phases (230 V each, charging ~11–22 kW): you map three sensors each for production, consumption and grid import (one per phase); the integration sums them and balances the charging speed across all three phases. In three-phase every amperage setting means roughly 3× the power of single-phase (e.g. 16 A ≈ 11 kW) and the minimum is ~4.1 kW — make sure your battery inverter can sustain the chosen power.",
         "data": {
-          "ev_charger_switch": "Charger switch",
-          "ev_charger_current": "Charging current control",
-          "ev_charger_status": "Charger status sensor"
+          "phase_mode": "Electrical phases"
         },
         "data_description": {
-          "ev_charger_switch": "Switch entity that turns the charger on or off.",
-          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+          "phase_mode": "Single-phase is the default and matches most homes. Choose three-phase only if your installation is genuinely three-phase."
         }
       },
       "sensors": {
         "title": "Update Energy Sensors - Step {step}/{total_steps}",
-        "description": "Update the energy and SOC sensors used by the integration.",
+        "description": "Update the energy and SOC sensors used by the integration. In three-phase mode you map three sensors per quantity (one per phase).",
         "data": {
           "soc_car": "EV battery SOC",
           "soc_home": "Home battery SOC",
           "fv_production": "Solar production",
           "home_consumption": "Home consumption",
-          "grid_import": "Grid import"
+          "grid_import": "Grid import",
+          "fv_production_l2": "Solar production (L2)",
+          "fv_production_l3": "Solar production (L3)",
+          "home_consumption_l2": "Home consumption (L2)",
+          "home_consumption_l3": "Home consumption (L3)",
+          "grid_import_l2": "Grid import (L2)",
+          "grid_import_l3": "Grid import (L3)"
         },
         "data_description": {
           "soc_car": "Sensor with the EV state of charge in percent.",
           "soc_home": "Sensor with the home battery state of charge in percent.",
           "fv_production": "Sensor with current PV production in watts.",
           "home_consumption": "Sensor with current household consumption in watts, excluding EV charging when possible.",
-          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid."
+          "grid_import": "Sensor with imported grid power in watts. Positive values mean import from the grid.",
+          "fv_production_l2": "Solar production on phase L2, in watts.",
+          "fv_production_l3": "Solar production on phase L3, in watts.",
+          "home_consumption_l2": "Home consumption on phase L2, in watts.",
+          "home_consumption_l3": "Home consumption on phase L3, in watts.",
+          "grid_import_l2": "Grid import on phase L2, in watts.",
+          "grid_import_l3": "Grid import on phase L3, in watts."
         }
       },
       "pv_forecast": {
@@ -258,6 +330,30 @@
         },
         "data_description": {
           "create_dashboard": "When enabled, a Lovelace dashboard preloaded with all integration entities is added to the sidebar at /ev-smart-charger."
+        }
+      },
+      "entities": {
+        "title": "Update Charger Entities - Step {step}/{total_steps}",
+        "description": "Compatibility wrapper around the canonical reconfigure flow. Update the charger entities for this entry.",
+        "data": {
+          "ev_charger_switch": "Charger switch",
+          "ev_charger_current": "Charging current control",
+          "ev_charger_status": "Charger status sensor"
+        },
+        "data_description": {
+          "ev_charger_switch": "Switch entity that turns the charger on or off.",
+          "ev_charger_current": "Current control entity. Supported domains: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Status sensor that reports `charger_charging`, `charger_free`, `charger_end`, or `charger_wait`."
+        }
+      },
+      "charger_model": {
+        "title": "Update Wallbox Model - Step {step}/{total_steps}",
+        "description": "Choose how your wallbox adjusts the charging current.\n\n**Tuya** — current is set only to fixed values (6, 8, 10, 13, 16, 20, 24, 32 A); to lower it the wallbox is switched off and on (a few seconds' pause). This is the default and works with the most common wallboxes — pick it if unsure.\n\n**Generic** — accepts any whole-ampere value (6, 7, 8, … 32 A) via a `number` entity: finer control and, when decreasing, the current drops live without interrupting the session.",
+        "data": {
+          "charger_model": "Wallbox type"
+        },
+        "data_description": {
+          "charger_model": "Tuya = fixed steps (default). Generic = 1 A steps for non-Tuya wallboxes that expose the current as a number entity."
         }
       }
     },
@@ -440,6 +536,20 @@
       },
       "evsc_car_ready_time": {
         "name": "Car ready time"
+      }
+    }
+  },
+  "selector": {
+    "phase_mode": {
+      "options": {
+        "single": "Single-phase",
+        "three": "Three-phase"
+      }
+    },
+    "charger_model": {
+      "options": {
+        "tuya": "Tuya (standard)",
+        "generic": "Generic (1 A steps)"
       }
     }
   }

--- a/custom_components/ev_smart_charger/translations/it.json
+++ b/custom_components/ev_smart_charger/translations/it.json
@@ -27,20 +27,32 @@
       },
       "sensors": {
         "title": "Sensori Energia - Passo {step}/{total_steps}",
-        "description": "Mappa i sensori usati da Solar Surplus, Priority Balancer e Night Smart Charge.",
+        "description": "Mappa i sensori usati da Solar Surplus, Priority Balancer e Night Smart Charge. In trifase mappi tre sensori per grandezza (uno per fase).",
         "data": {
           "soc_car": "SOC batteria EV",
           "soc_home": "SOC batteria casa",
           "fv_production": "Produzione solare",
           "home_consumption": "Consumo casa",
-          "grid_import": "Prelievo da rete"
+          "grid_import": "Prelievo da rete",
+          "fv_production_l2": "Produzione solare (L2)",
+          "fv_production_l3": "Produzione solare (L3)",
+          "home_consumption_l2": "Consumo casa (L2)",
+          "home_consumption_l3": "Consumo casa (L3)",
+          "grid_import_l2": "Prelievo rete (L2)",
+          "grid_import_l3": "Prelievo rete (L3)"
         },
         "data_description": {
           "soc_car": "Sensore con lo stato di carica EV in percentuale.",
           "soc_home": "Sensore con lo stato di carica della batteria di casa in percentuale.",
           "fv_production": "Sensore con la produzione FV corrente in watt.",
           "home_consumption": "Sensore con il consumo di casa in watt, preferibilmente senza includere la ricarica EV.",
-          "grid_import": "Sensore con la potenza importata dalla rete in watt. Valori positivi indicano import."
+          "grid_import": "Sensore con la potenza importata dalla rete in watt. Valori positivi indicano import.",
+          "fv_production_l2": "Produzione solare sulla fase L2, in watt.",
+          "fv_production_l3": "Produzione solare sulla fase L3, in watt.",
+          "home_consumption_l2": "Consumo casa sulla fase L2, in watt.",
+          "home_consumption_l3": "Consumo casa sulla fase L3, in watt.",
+          "grid_import_l2": "Prelievo rete sulla fase L2, in watt.",
+          "grid_import_l3": "Prelievo rete sulla fase L3, in watt."
         }
       },
       "pv_forecast": {
@@ -90,35 +102,43 @@
         }
       },
       "reconfigure": {
-        "title": "Riconfigura Entita Charger - Passo {step}/{total_steps}",
-        "description": "Aggiorna le entita del charger per questa config entry.",
+        "title": "Riconfigura modalità impianto - Passo {step}/{total_steps}",
+        "description": "Scegli com'è fatto il tuo impianto elettrico.\n\n**Monofase** — una sola fase (230 V, ricarica fino a ~3,7 kW): mappi un sensore per la produzione, uno per il consumo e uno per il prelievo dalla rete, come adesso. È il caso più comune.\n\n**Trifase** — tre fasi (230 V ciascuna, ricarica ~11–22 kW): mappi tre sensori per la produzione, tre per il consumo e tre per il prelievo (uno per fase); l'integrazione li somma e bilancia la velocità di ricarica sulle tre fasi. In trifase ogni valore di amperaggio vale circa 3× la potenza del monofase (es. 16 A ≈ 11 kW) e il minimo è ~4,1 kW: assicurati che l'inverter della batteria regga la potenza scelta.",
         "data": {
-          "ev_charger_switch": "Switch charger",
-          "ev_charger_current": "Controllo corrente di ricarica",
-          "ev_charger_status": "Sensore stato charger"
+          "phase_mode": "Fasi elettriche"
         },
         "data_description": {
-          "ev_charger_switch": "Entita switch che accende o spegne il charger.",
-          "ev_charger_current": "Entita per la corrente. Domini supportati: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Sensore stato che riporta `charger_charging`, `charger_free`, `charger_end` o `charger_wait`."
+          "phase_mode": "Il monofase è il default e va bene per la maggior parte delle case. Scegli trifase solo se il tuo impianto è davvero trifase."
         }
       },
       "reconfigure_sensors": {
         "title": "Riconfigura Sensori Energia - Passo {step}/{total_steps}",
-        "description": "Aggiorna i sensori energia e SOC usati dall'integrazione.",
+        "description": "Aggiorna i sensori energia e SOC usati dall'integrazione. In trifase mappi tre sensori per grandezza (uno per fase).",
         "data": {
           "soc_car": "SOC batteria EV",
           "soc_home": "SOC batteria casa",
           "fv_production": "Produzione solare",
           "home_consumption": "Consumo casa",
-          "grid_import": "Prelievo da rete"
+          "grid_import": "Prelievo da rete",
+          "fv_production_l2": "Produzione solare (L2)",
+          "fv_production_l3": "Produzione solare (L3)",
+          "home_consumption_l2": "Consumo casa (L2)",
+          "home_consumption_l3": "Consumo casa (L3)",
+          "grid_import_l2": "Prelievo rete (L2)",
+          "grid_import_l3": "Prelievo rete (L3)"
         },
         "data_description": {
           "soc_car": "Sensore con lo stato di carica EV in percentuale.",
           "soc_home": "Sensore con lo stato di carica della batteria di casa in percentuale.",
           "fv_production": "Sensore con la produzione FV corrente in watt.",
           "home_consumption": "Sensore con il consumo di casa in watt, preferibilmente senza includere la ricarica EV.",
-          "grid_import": "Sensore con la potenza importata dalla rete in watt. Valori positivi indicano import."
+          "grid_import": "Sensore con la potenza importata dalla rete in watt. Valori positivi indicano import.",
+          "fv_production_l2": "Produzione solare sulla fase L2, in watt.",
+          "fv_production_l3": "Produzione solare sulla fase L3, in watt.",
+          "home_consumption_l2": "Consumo casa sulla fase L2, in watt.",
+          "home_consumption_l3": "Consumo casa sulla fase L3, in watt.",
+          "grid_import_l2": "Prelievo rete sulla fase L2, in watt.",
+          "grid_import_l3": "Prelievo rete sulla fase L3, in watt."
         }
       },
       "reconfigure_pv_forecast": {
@@ -166,6 +186,50 @@
         "data_description": {
           "create_dashboard": "Attiva/disattiva la dashboard EV Smart Charger dedicata."
         }
+      },
+      "reconfigure_entities": {
+        "title": "Riconfigura Entita Charger - Passo {step}/{total_steps}",
+        "description": "Aggiorna le entita del charger per questa config entry.",
+        "data": {
+          "ev_charger_switch": "Switch charger",
+          "ev_charger_current": "Controllo corrente di ricarica",
+          "ev_charger_status": "Sensore stato charger"
+        },
+        "data_description": {
+          "ev_charger_switch": "Entita switch che accende o spegne il charger.",
+          "ev_charger_current": "Entita per la corrente. Domini supportati: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Sensore stato che riporta `charger_charging`, `charger_free`, `charger_end` o `charger_wait`."
+        }
+      },
+      "phase_mode": {
+        "title": "Modalità impianto - Passo {step}/{total_steps}",
+        "description": "Scegli com'è fatto il tuo impianto elettrico.\n\n**Monofase** — una sola fase (230 V, ricarica fino a ~3,7 kW): mappi un sensore per la produzione, uno per il consumo e uno per il prelievo dalla rete, come adesso. È il caso più comune.\n\n**Trifase** — tre fasi (230 V ciascuna, ricarica ~11–22 kW): mappi tre sensori per la produzione, tre per il consumo e tre per il prelievo (uno per fase); l'integrazione li somma e bilancia la velocità di ricarica sulle tre fasi. In trifase ogni valore di amperaggio vale circa 3× la potenza del monofase (es. 16 A ≈ 11 kW) e il minimo è ~4,1 kW: assicurati che l'inverter della batteria regga la potenza scelta.",
+        "data": {
+          "phase_mode": "Fasi elettriche"
+        },
+        "data_description": {
+          "phase_mode": "Il monofase è il default e va bene per la maggior parte delle case. Scegli trifase solo se il tuo impianto è davvero trifase."
+        }
+      },
+      "charger_model": {
+        "title": "Modello wallbox - Passo {step}/{total_steps}",
+        "description": "Scegli come la tua wallbox regola la corrente di ricarica.\n\n**Tuya** — la corrente si imposta solo su valori fissi (6, 8, 10, 13, 16, 20, 24, 32 A); per abbassarla la wallbox viene spenta e riaccesa (qualche secondo di pausa). È il default e funziona con i wallbox più diffusi: scegli questa se non sai.\n\n**Generica** — accetta qualsiasi valore intero di corrente (6, 7, 8, … 32 A) tramite un'entità `number`: regolazione più fine e, in diminuzione, la corrente cala al volo senza interrompere la ricarica.",
+        "data": {
+          "charger_model": "Tipo di wallbox"
+        },
+        "data_description": {
+          "charger_model": "Tuya = scatti fissi (default). Generica = scatti da 1 A per wallbox non-Tuya che espongono la corrente come entità number."
+        }
+      },
+      "reconfigure_charger_model": {
+        "title": "Riconfigura modello wallbox - Passo {step}/{total_steps}",
+        "description": "Scegli come la tua wallbox regola la corrente di ricarica.\n\n**Tuya** — la corrente si imposta solo su valori fissi (6, 8, 10, 13, 16, 20, 24, 32 A); per abbassarla la wallbox viene spenta e riaccesa (qualche secondo di pausa). È il default e funziona con i wallbox più diffusi: scegli questa se non sai.\n\n**Generica** — accetta qualsiasi valore intero di corrente (6, 7, 8, … 32 A) tramite un'entità `number`: regolazione più fine e, in diminuzione, la corrente cala al volo senza interrompere la ricarica.",
+        "data": {
+          "charger_model": "Tipo di wallbox"
+        },
+        "data_description": {
+          "charger_model": "Tuya = scatti fissi (default). Generica = scatti da 1 A per wallbox non-Tuya che espongono la corrente come entità number."
+        }
       }
     },
     "error": {
@@ -183,35 +247,43 @@
   "options": {
     "step": {
       "init": {
-        "title": "Aggiorna Entita Charger - Passo {step}/{total_steps}",
-        "description": "Wrapper di compatibilita del flow canonico di reconfigure. Aggiorna le entita del charger per questa entry.",
+        "title": "Aggiorna modalità impianto - Passo {step}/{total_steps}",
+        "description": "Scegli com'è fatto il tuo impianto elettrico.\n\n**Monofase** — una sola fase (230 V, ricarica fino a ~3,7 kW): mappi un sensore per la produzione, uno per il consumo e uno per il prelievo dalla rete, come adesso. È il caso più comune.\n\n**Trifase** — tre fasi (230 V ciascuna, ricarica ~11–22 kW): mappi tre sensori per la produzione, tre per il consumo e tre per il prelievo (uno per fase); l'integrazione li somma e bilancia la velocità di ricarica sulle tre fasi. In trifase ogni valore di amperaggio vale circa 3× la potenza del monofase (es. 16 A ≈ 11 kW) e il minimo è ~4,1 kW: assicurati che l'inverter della batteria regga la potenza scelta.",
         "data": {
-          "ev_charger_switch": "Switch charger",
-          "ev_charger_current": "Controllo corrente di ricarica",
-          "ev_charger_status": "Sensore stato charger"
+          "phase_mode": "Fasi elettriche"
         },
         "data_description": {
-          "ev_charger_switch": "Entita switch che accende o spegne il charger.",
-          "ev_charger_current": "Entita per la corrente. Domini supportati: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Sensore stato che riporta `charger_charging`, `charger_free`, `charger_end` o `charger_wait`."
+          "phase_mode": "Il monofase è il default e va bene per la maggior parte delle case. Scegli trifase solo se il tuo impianto è davvero trifase."
         }
       },
       "sensors": {
         "title": "Aggiorna Sensori Energia - Passo {step}/{total_steps}",
-        "description": "Aggiorna i sensori energia e SOC usati dall'integrazione.",
+        "description": "Aggiorna i sensori energia e SOC usati dall'integrazione. In trifase mappi tre sensori per grandezza (uno per fase).",
         "data": {
           "soc_car": "SOC batteria EV",
           "soc_home": "SOC batteria casa",
           "fv_production": "Produzione solare",
           "home_consumption": "Consumo casa",
-          "grid_import": "Prelievo da rete"
+          "grid_import": "Prelievo da rete",
+          "fv_production_l2": "Produzione solare (L2)",
+          "fv_production_l3": "Produzione solare (L3)",
+          "home_consumption_l2": "Consumo casa (L2)",
+          "home_consumption_l3": "Consumo casa (L3)",
+          "grid_import_l2": "Prelievo rete (L2)",
+          "grid_import_l3": "Prelievo rete (L3)"
         },
         "data_description": {
           "soc_car": "Sensore con lo stato di carica EV in percentuale.",
           "soc_home": "Sensore con lo stato di carica della batteria di casa in percentuale.",
           "fv_production": "Sensore con la produzione FV corrente in watt.",
           "home_consumption": "Sensore con il consumo di casa in watt, preferibilmente senza includere la ricarica EV.",
-          "grid_import": "Sensore con la potenza importata dalla rete in watt. Valori positivi indicano import."
+          "grid_import": "Sensore con la potenza importata dalla rete in watt. Valori positivi indicano import.",
+          "fv_production_l2": "Produzione solare sulla fase L2, in watt.",
+          "fv_production_l3": "Produzione solare sulla fase L3, in watt.",
+          "home_consumption_l2": "Consumo casa sulla fase L2, in watt.",
+          "home_consumption_l3": "Consumo casa sulla fase L3, in watt.",
+          "grid_import_l2": "Prelievo rete sulla fase L2, in watt.",
+          "grid_import_l3": "Prelievo rete sulla fase L3, in watt."
         }
       },
       "pv_forecast": {
@@ -258,6 +330,30 @@
         },
         "data_description": {
           "create_dashboard": "Se attivo, viene creata una dashboard Lovelace precaricata con tutte le entita su /ev-smart-charger."
+        }
+      },
+      "entities": {
+        "title": "Aggiorna Entita Charger - Passo {step}/{total_steps}",
+        "description": "Wrapper di compatibilita del flow canonico di reconfigure. Aggiorna le entita del charger per questa entry.",
+        "data": {
+          "ev_charger_switch": "Switch charger",
+          "ev_charger_current": "Controllo corrente di ricarica",
+          "ev_charger_status": "Sensore stato charger"
+        },
+        "data_description": {
+          "ev_charger_switch": "Entita switch che accende o spegne il charger.",
+          "ev_charger_current": "Entita per la corrente. Domini supportati: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Sensore stato che riporta `charger_charging`, `charger_free`, `charger_end` o `charger_wait`."
+        }
+      },
+      "charger_model": {
+        "title": "Aggiorna modello wallbox - Passo {step}/{total_steps}",
+        "description": "Scegli come la tua wallbox regola la corrente di ricarica.\n\n**Tuya** — la corrente si imposta solo su valori fissi (6, 8, 10, 13, 16, 20, 24, 32 A); per abbassarla la wallbox viene spenta e riaccesa (qualche secondo di pausa). È il default e funziona con i wallbox più diffusi: scegli questa se non sai.\n\n**Generica** — accetta qualsiasi valore intero di corrente (6, 7, 8, … 32 A) tramite un'entità `number`: regolazione più fine e, in diminuzione, la corrente cala al volo senza interrompere la ricarica.",
+        "data": {
+          "charger_model": "Tipo di wallbox"
+        },
+        "data_description": {
+          "charger_model": "Tuya = scatti fissi (default). Generica = scatti da 1 A per wallbox non-Tuya che espongono la corrente come entità number."
         }
       }
     },
@@ -440,6 +536,20 @@
       },
       "evsc_car_ready_time": {
         "name": "Ora auto pronta"
+      }
+    }
+  },
+  "selector": {
+    "phase_mode": {
+      "options": {
+        "single": "Monofase",
+        "three": "Trifase"
+      }
+    },
+    "charger_model": {
+      "options": {
+        "tuya": "Tuya (standard)",
+        "generic": "Generica (scatti da 1 A)"
       }
     }
   }

--- a/custom_components/ev_smart_charger/translations/nl.json
+++ b/custom_components/ev_smart_charger/translations/nl.json
@@ -27,20 +27,32 @@
       },
       "sensors": {
         "title": "Energiesensoren - Stap {step}/{total_steps}",
-        "description": "Koppel de sensoren die door Solar Surplus, Priority Balancer en Night Smart Charge worden gebruikt.",
+        "description": "Koppel de sensoren die door Solar Surplus, Priority Balancer en Night Smart Charge worden gebruikt. In driefase koppel je drie sensoren per grootheid (één per fase).",
         "data": {
           "soc_car": "EV-batterij-SOC",
           "soc_home": "Thuisbatterij-SOC",
           "fv_production": "Zonneproductie",
           "home_consumption": "Woningverbruik",
-          "grid_import": "Netafname"
+          "grid_import": "Netafname",
+          "fv_production_l2": "Zonneproductie (L2)",
+          "fv_production_l3": "Zonneproductie (L3)",
+          "home_consumption_l2": "Verbruik woning (L2)",
+          "home_consumption_l3": "Verbruik woning (L3)",
+          "grid_import_l2": "Netafname (L2)",
+          "grid_import_l3": "Netafname (L3)"
         },
         "data_description": {
           "soc_car": "Sensor met de laadtoestand van de EV in procenten.",
           "soc_home": "Sensor met de laadtoestand van de thuisbatterij in procenten.",
           "fv_production": "Sensor met de actuele PV-productie in watt.",
           "home_consumption": "Sensor met het actuele huishoudelijke verbruik in watt, indien mogelijk exclusief EV-laden.",
-          "grid_import": "Sensor met uit het net afgenomen vermogen in watt. Positieve waarden betekenen afname uit het net."
+          "grid_import": "Sensor met uit het net afgenomen vermogen in watt. Positieve waarden betekenen afname uit het net.",
+          "fv_production_l2": "Zonneproductie op fase L2, in watt.",
+          "fv_production_l3": "Zonneproductie op fase L3, in watt.",
+          "home_consumption_l2": "Verbruik woning op fase L2, in watt.",
+          "home_consumption_l3": "Verbruik woning op fase L3, in watt.",
+          "grid_import_l2": "Netafname op fase L2, in watt.",
+          "grid_import_l3": "Netafname op fase L3, in watt."
         }
       },
       "pv_forecast": {
@@ -90,35 +102,43 @@
         }
       },
       "reconfigure": {
-        "title": "Lader-entiteiten opnieuw configureren - Stap {step}/{total_steps}",
-        "description": "Werk de lader-entiteiten voor deze config entry bij.",
+        "title": "Fasemodus opnieuw configureren - Stap {step}/{total_steps}",
+        "description": "Kies hoe je elektrische installatie is bekabeld.\n\n**Eénfase** — één fase (230 V, laden tot ~3,7 kW): je koppelt één sensor voor zonneproductie, één voor verbruik en één voor netafname, zoals nu. Dit is de meest voorkomende opstelling.\n\n**Driefase** — drie fasen (230 V elk, laden ~11–22 kW): je koppelt drie sensoren voor productie, drie voor verbruik en drie voor netafname (één per fase); de integratie telt ze op en verdeelt de laadsnelheid over de drie fasen. Bij driefase staat elke ampèrewaarde voor ongeveer 3× het vermogen van éénfase (bijv. 16 A ≈ 11 kW) en het minimum is ~4,1 kW — zorg dat je thuisbatterij-omvormer dat vermogen aankan.",
         "data": {
-          "ev_charger_switch": "Lader-schakelaar",
-          "ev_charger_current": "Laadstroomregeling",
-          "ev_charger_status": "Laderstatussensor"
+          "phase_mode": "Elektrische fasen"
         },
         "data_description": {
-          "ev_charger_switch": "Schakelaar-entiteit die de lader in- of uitschakelt.",
-          "ev_charger_current": "Entiteit voor stroomregeling. Ondersteunde domeinen: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Statussensor die `charger_charging`, `charger_free`, `charger_end` of `charger_wait` rapporteert."
+          "phase_mode": "Eénfase is de standaard en past bij de meeste woningen. Kies alleen driefase als je installatie echt driefase is."
         }
       },
       "reconfigure_sensors": {
         "title": "Energiesensoren opnieuw configureren - Stap {step}/{total_steps}",
-        "description": "Werk de energie- en SOC-sensoren bij die door de integratie worden gebruikt.",
+        "description": "Werk de energie- en SOC-sensoren bij die door de integratie worden gebruikt. In driefase koppel je drie sensoren per grootheid (één per fase).",
         "data": {
           "soc_car": "EV-batterij-SOC",
           "soc_home": "Thuisbatterij-SOC",
           "fv_production": "Zonneproductie",
           "home_consumption": "Woningverbruik",
-          "grid_import": "Netafname"
+          "grid_import": "Netafname",
+          "fv_production_l2": "Zonneproductie (L2)",
+          "fv_production_l3": "Zonneproductie (L3)",
+          "home_consumption_l2": "Verbruik woning (L2)",
+          "home_consumption_l3": "Verbruik woning (L3)",
+          "grid_import_l2": "Netafname (L2)",
+          "grid_import_l3": "Netafname (L3)"
         },
         "data_description": {
           "soc_car": "Sensor met de laadtoestand van de EV in procenten.",
           "soc_home": "Sensor met de laadtoestand van de thuisbatterij in procenten.",
           "fv_production": "Sensor met de actuele PV-productie in watt.",
           "home_consumption": "Sensor met het actuele huishoudelijke verbruik in watt, indien mogelijk exclusief EV-laden.",
-          "grid_import": "Sensor met uit het net afgenomen vermogen in watt. Positieve waarden betekenen afname uit het net."
+          "grid_import": "Sensor met uit het net afgenomen vermogen in watt. Positieve waarden betekenen afname uit het net.",
+          "fv_production_l2": "Zonneproductie op fase L2, in watt.",
+          "fv_production_l3": "Zonneproductie op fase L3, in watt.",
+          "home_consumption_l2": "Verbruik woning op fase L2, in watt.",
+          "home_consumption_l3": "Verbruik woning op fase L3, in watt.",
+          "grid_import_l2": "Netafname op fase L2, in watt.",
+          "grid_import_l3": "Netafname op fase L3, in watt."
         }
       },
       "reconfigure_pv_forecast": {
@@ -166,6 +186,50 @@
         "data_description": {
           "create_dashboard": "Schakelen om het toegewijde EV Smart Charger Lovelace-dashboard aan te maken of te verwijderen."
         }
+      },
+      "reconfigure_entities": {
+        "title": "Lader-entiteiten opnieuw configureren - Stap {step}/{total_steps}",
+        "description": "Werk de lader-entiteiten voor deze config entry bij.",
+        "data": {
+          "ev_charger_switch": "Lader-schakelaar",
+          "ev_charger_current": "Laadstroomregeling",
+          "ev_charger_status": "Laderstatussensor"
+        },
+        "data_description": {
+          "ev_charger_switch": "Schakelaar-entiteit die de lader in- of uitschakelt.",
+          "ev_charger_current": "Entiteit voor stroomregeling. Ondersteunde domeinen: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Statussensor die `charger_charging`, `charger_free`, `charger_end` of `charger_wait` rapporteert."
+        }
+      },
+      "phase_mode": {
+        "title": "Fasemodus - Stap {step}/{total_steps}",
+        "description": "Kies hoe je elektrische installatie is bekabeld.\n\n**Eénfase** — één fase (230 V, laden tot ~3,7 kW): je koppelt één sensor voor zonneproductie, één voor verbruik en één voor netafname, zoals nu. Dit is de meest voorkomende opstelling.\n\n**Driefase** — drie fasen (230 V elk, laden ~11–22 kW): je koppelt drie sensoren voor productie, drie voor verbruik en drie voor netafname (één per fase); de integratie telt ze op en verdeelt de laadsnelheid over de drie fasen. Bij driefase staat elke ampèrewaarde voor ongeveer 3× het vermogen van éénfase (bijv. 16 A ≈ 11 kW) en het minimum is ~4,1 kW — zorg dat je thuisbatterij-omvormer dat vermogen aankan.",
+        "data": {
+          "phase_mode": "Elektrische fasen"
+        },
+        "data_description": {
+          "phase_mode": "Eénfase is de standaard en past bij de meeste woningen. Kies alleen driefase als je installatie echt driefase is."
+        }
+      },
+      "charger_model": {
+        "title": "Wallbox-model - Stap {step}/{total_steps}",
+        "description": "Kies hoe je wallbox de laadstroom regelt.\n\n**Tuya** — de stroom kan alleen op vaste waarden (6, 8, 10, 13, 16, 20, 24, 32 A); om te verlagen wordt de wallbox uit- en weer ingeschakeld (een paar seconden pauze). Dit is de standaard en werkt met de meeste wallboxen — kies dit bij twijfel.\n\n**Generiek** — accepteert elke hele ampèrewaarde (6, 7, 8, … 32 A) via een `number`-entiteit: fijnere regeling en bij verlagen daalt de stroom live zonder de sessie te onderbreken.",
+        "data": {
+          "charger_model": "Type wallbox"
+        },
+        "data_description": {
+          "charger_model": "Tuya = vaste stappen (standaard). Generiek = stappen van 1 A voor niet-Tuya-wallboxen die de stroom als number-entiteit aanbieden."
+        }
+      },
+      "reconfigure_charger_model": {
+        "title": "Wallbox-model opnieuw configureren - Stap {step}/{total_steps}",
+        "description": "Kies hoe je wallbox de laadstroom regelt.\n\n**Tuya** — de stroom kan alleen op vaste waarden (6, 8, 10, 13, 16, 20, 24, 32 A); om te verlagen wordt de wallbox uit- en weer ingeschakeld (een paar seconden pauze). Dit is de standaard en werkt met de meeste wallboxen — kies dit bij twijfel.\n\n**Generiek** — accepteert elke hele ampèrewaarde (6, 7, 8, … 32 A) via een `number`-entiteit: fijnere regeling en bij verlagen daalt de stroom live zonder de sessie te onderbreken.",
+        "data": {
+          "charger_model": "Type wallbox"
+        },
+        "data_description": {
+          "charger_model": "Tuya = vaste stappen (standaard). Generiek = stappen van 1 A voor niet-Tuya-wallboxen die de stroom als number-entiteit aanbieden."
+        }
       }
     },
     "error": {
@@ -183,35 +247,43 @@
   "options": {
     "step": {
       "init": {
-        "title": "Lader-entiteiten bijwerken - Stap {step}/{total_steps}",
-        "description": "Compatibiliteitslaag rond de canonieke herconfiguratiestroom. Werk de lader-entiteiten voor deze entry bij.",
+        "title": "Fasemodus bijwerken - Stap {step}/{total_steps}",
+        "description": "Kies hoe je elektrische installatie is bekabeld.\n\n**Eénfase** — één fase (230 V, laden tot ~3,7 kW): je koppelt één sensor voor zonneproductie, één voor verbruik en één voor netafname, zoals nu. Dit is de meest voorkomende opstelling.\n\n**Driefase** — drie fasen (230 V elk, laden ~11–22 kW): je koppelt drie sensoren voor productie, drie voor verbruik en drie voor netafname (één per fase); de integratie telt ze op en verdeelt de laadsnelheid over de drie fasen. Bij driefase staat elke ampèrewaarde voor ongeveer 3× het vermogen van éénfase (bijv. 16 A ≈ 11 kW) en het minimum is ~4,1 kW — zorg dat je thuisbatterij-omvormer dat vermogen aankan.",
         "data": {
-          "ev_charger_switch": "Lader-schakelaar",
-          "ev_charger_current": "Laadstroomregeling",
-          "ev_charger_status": "Laderstatussensor"
+          "phase_mode": "Elektrische fasen"
         },
         "data_description": {
-          "ev_charger_switch": "Schakelaar-entiteit die de lader in- of uitschakelt.",
-          "ev_charger_current": "Entiteit voor stroomregeling. Ondersteunde domeinen: `number`, `input_number`, `select`, `input_select`.",
-          "ev_charger_status": "Statussensor die `charger_charging`, `charger_free`, `charger_end` of `charger_wait` rapporteert."
+          "phase_mode": "Eénfase is de standaard en past bij de meeste woningen. Kies alleen driefase als je installatie echt driefase is."
         }
       },
       "sensors": {
         "title": "Energiesensoren bijwerken - Stap {step}/{total_steps}",
-        "description": "Werk de energie- en SOC-sensoren bij die door de integratie worden gebruikt.",
+        "description": "Werk de energie- en SOC-sensoren bij die door de integratie worden gebruikt. In driefase koppel je drie sensoren per grootheid (één per fase).",
         "data": {
           "soc_car": "EV-batterij-SOC",
           "soc_home": "Thuisbatterij-SOC",
           "fv_production": "Zonneproductie",
           "home_consumption": "Woningverbruik",
-          "grid_import": "Netafname"
+          "grid_import": "Netafname",
+          "fv_production_l2": "Zonneproductie (L2)",
+          "fv_production_l3": "Zonneproductie (L3)",
+          "home_consumption_l2": "Verbruik woning (L2)",
+          "home_consumption_l3": "Verbruik woning (L3)",
+          "grid_import_l2": "Netafname (L2)",
+          "grid_import_l3": "Netafname (L3)"
         },
         "data_description": {
           "soc_car": "Sensor met de laadtoestand van de EV in procenten.",
           "soc_home": "Sensor met de laadtoestand van de thuisbatterij in procenten.",
           "fv_production": "Sensor met de actuele PV-productie in watt.",
           "home_consumption": "Sensor met het actuele huishoudelijke verbruik in watt, indien mogelijk exclusief EV-laden.",
-          "grid_import": "Sensor met uit het net afgenomen vermogen in watt. Positieve waarden betekenen afname uit het net."
+          "grid_import": "Sensor met uit het net afgenomen vermogen in watt. Positieve waarden betekenen afname uit het net.",
+          "fv_production_l2": "Zonneproductie op fase L2, in watt.",
+          "fv_production_l3": "Zonneproductie op fase L3, in watt.",
+          "home_consumption_l2": "Verbruik woning op fase L2, in watt.",
+          "home_consumption_l3": "Verbruik woning op fase L3, in watt.",
+          "grid_import_l2": "Netafname op fase L2, in watt.",
+          "grid_import_l3": "Netafname op fase L3, in watt."
         }
       },
       "pv_forecast": {
@@ -258,6 +330,30 @@
         },
         "data_description": {
           "create_dashboard": "Indien ingeschakeld wordt een Lovelace-dashboard met alle integratie-entiteiten toegevoegd aan de zijbalk op /ev-smart-charger."
+        }
+      },
+      "entities": {
+        "title": "Lader-entiteiten bijwerken - Stap {step}/{total_steps}",
+        "description": "Compatibiliteitslaag rond de canonieke herconfiguratiestroom. Werk de lader-entiteiten voor deze entry bij.",
+        "data": {
+          "ev_charger_switch": "Lader-schakelaar",
+          "ev_charger_current": "Laadstroomregeling",
+          "ev_charger_status": "Laderstatussensor"
+        },
+        "data_description": {
+          "ev_charger_switch": "Schakelaar-entiteit die de lader in- of uitschakelt.",
+          "ev_charger_current": "Entiteit voor stroomregeling. Ondersteunde domeinen: `number`, `input_number`, `select`, `input_select`.",
+          "ev_charger_status": "Statussensor die `charger_charging`, `charger_free`, `charger_end` of `charger_wait` rapporteert."
+        }
+      },
+      "charger_model": {
+        "title": "Wallbox-model bijwerken - Stap {step}/{total_steps}",
+        "description": "Kies hoe je wallbox de laadstroom regelt.\n\n**Tuya** — de stroom kan alleen op vaste waarden (6, 8, 10, 13, 16, 20, 24, 32 A); om te verlagen wordt de wallbox uit- en weer ingeschakeld (een paar seconden pauze). Dit is de standaard en werkt met de meeste wallboxen — kies dit bij twijfel.\n\n**Generiek** — accepteert elke hele ampèrewaarde (6, 7, 8, … 32 A) via een `number`-entiteit: fijnere regeling en bij verlagen daalt de stroom live zonder de sessie te onderbreken.",
+        "data": {
+          "charger_model": "Type wallbox"
+        },
+        "data_description": {
+          "charger_model": "Tuya = vaste stappen (standaard). Generiek = stappen van 1 A voor niet-Tuya-wallboxen die de stroom als number-entiteit aanbieden."
         }
       }
     },
@@ -440,6 +536,20 @@
       },
       "evsc_car_ready_time": {
         "name": "Tijd auto klaar"
+      }
+    }
+  },
+  "selector": {
+    "phase_mode": {
+      "options": {
+        "single": "Eénfase",
+        "three": "Driefase"
+      }
+    },
+    "charger_model": {
+      "options": {
+        "tuya": "Tuya (standaard)",
+        "generic": "Generiek (stappen van 1 A)"
       }
     }
   }

--- a/custom_components/ev_smart_charger/utils/amperage_helper.py
+++ b/custom_components/ev_smart_charger/utils/amperage_helper.py
@@ -24,6 +24,8 @@ class AmperageCalculator:
         surplus_watts: float,
         current_amps: int = 0,
         battery_support_amps: Optional[int] = None,
+        amp_levels: Optional[list] = None,
+        voltage: Optional[float] = None,
     ) -> Tuple[int, str]:
         """Calculate target amperage from surplus with battery support fallback.
 
@@ -47,14 +49,15 @@ class AmperageCalculator:
             >>> AmperageCalculator.calculate_from_surplus(500, 8, 16)
             (16, 'Battery fallback (2.2A)')
         """
-        surplus_amps = surplus_watts / VOLTAGE_EU
+        levels = amp_levels if amp_levels is not None else CHARGER_AMP_LEVELS
+        surplus_amps = surplus_watts / (voltage if voltage is not None else VOLTAGE_EU)
         is_charging = current_amps > 0
 
         # CASE 1: Surplus sufficient to charge (>= 6.5A)
         if surplus_amps >= SURPLUS_START_THRESHOLD:
             # Find highest amp level that fits within surplus
-            target = CHARGER_AMP_LEVELS[0]  # Start with minimum (6A)
-            for level in CHARGER_AMP_LEVELS:
+            target = levels[0]  # Start with minimum (6A)
+            for level in levels:
                 if level <= surplus_amps:
                     target = level
                 else:
@@ -87,11 +90,12 @@ class AmperageCalculator:
         return 0, f"Insufficient surplus ({surplus_amps:.1f}A < {SURPLUS_STOP_THRESHOLD}A)"
 
     @staticmethod
-    def get_next_level_down(current_amps: int) -> int:
+    def get_next_level_down(current_amps: int, amp_levels: Optional[list] = None) -> int:
         """Calculate one level down for reduction (grid import protection).
 
         Args:
             current_amps: Current charging amperage
+            amp_levels: Level set to use (default: Tuya CHARGER_AMP_LEVELS)
 
         Returns:
             Next lower amperage level, or 0 if at minimum
@@ -102,22 +106,26 @@ class AmperageCalculator:
             >>> AmperageCalculator.get_next_level_down(6)
             0
         """
+        levels = amp_levels if amp_levels is not None else CHARGER_AMP_LEVELS
         try:
-            current_index = CHARGER_AMP_LEVELS.index(current_amps)
+            current_index = levels.index(current_amps)
             if current_index > 0:
-                return CHARGER_AMP_LEVELS[current_index - 1]
+                return levels[current_index - 1]
         except ValueError:
-            # Current amps not in standard levels, return 0
+            # Current amps not in the level set, return 0
             pass
         return 0
 
     @staticmethod
-    def get_next_level_up(current_amps: int, max_amps: int) -> int:
+    def get_next_level_up(
+        current_amps: int, max_amps: int, amp_levels: Optional[list] = None
+    ) -> int:
         """Calculate one level up for recovery (gradual ramp-up).
 
         Args:
             current_amps: Current charging amperage
             max_amps: Maximum allowed amperage (target)
+            amp_levels: Level set to use (default: Tuya CHARGER_AMP_LEVELS)
 
         Returns:
             Next higher amperage level, capped at max_amps
@@ -128,13 +136,14 @@ class AmperageCalculator:
             >>> AmperageCalculator.get_next_level_up(13, 16)
             16
         """
+        levels = amp_levels if amp_levels is not None else CHARGER_AMP_LEVELS
         try:
-            current_index = CHARGER_AMP_LEVELS.index(current_amps)
-            if current_index < len(CHARGER_AMP_LEVELS) - 1:
-                next_amps = CHARGER_AMP_LEVELS[current_index + 1]
+            current_index = levels.index(current_amps)
+            if current_index < len(levels) - 1:
+                next_amps = levels[current_index + 1]
                 return min(next_amps, max_amps)
         except ValueError:
-            # Current amps not in standard levels, return max
+            # Current amps not in the level set, return max
             pass
         return max_amps
 

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -50,7 +50,8 @@ Makefile
 
 | File | Responsibility | Notes |
 | --- | --- | --- |
-| `custom_components/ev_smart_charger/charger_controller.py` | Serialized charger start, stop, and current changes | Owns current-control adapter for `number`, `input_number`, `select`, `input_select` |
+| `custom_components/ev_smart_charger/charger_controller.py` | Serialized charger start, stop, and current changes | Owns current-control adapter for `number`, `input_number`, `select`, `input_select`. v2.0.0: charger-model-aware levels + decrease sequence (tuya stop/set/start, generic live) |
+| `custom_components/ev_smart_charger/power_model.py` | `ChargingModel`: phase mode (single/three) + charger model (tuya/generic) single source | v2.0.0. Built once in `__init__`, shared via `runtime_data.power_model`; sums per-phase power sensors, exposes effective voltage + amp levels |
 | `custom_components/ev_smart_charger/automation_coordinator.py` | Ownership arbitration across charger-driving automations | Single control plane for Boost, Blocker, Night, and Solar |
 | `custom_components/ev_smart_charger/priority_balancer.py` | EV vs home battery decision logic | Decision-only, not a charger actuator |
 | `custom_components/ev_smart_charger/boost_charge.py` | Fixed-current override with SOC auto-stop; supports manual trigger and daily scheduled window | High-priority automation |

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -13,6 +13,13 @@ If it conflicts with historical notes, release files, or old session summaries, 
 - one charger status sensor
 - SOC, solar, load, grid, and optional forecast sensors
 
+Phase mode (v2.0.0) is an opt-in chosen in the config flow. In **single-phase**
+(default) production / home-consumption / grid-import are one sensor each and the
+watt→amp conversion uses 230 V — identical to pre-v2.0.0. In **three-phase** they
+are three sensors each (summed) and the conversion uses 3 × 230 = 690 V, so per-phase
+amperage thresholds and levels stay valid downstream. SOC sensors stay single. Charger
+model (v2.0.0) is also opt-in: see §4.
+
 The public charging profiles exposed in the UI are:
 
 - `manual`
@@ -82,6 +89,15 @@ The current-control adapter supports:
 
 The same native-service approach is used for external energy forecast targets. Integration-owned entities are no longer updated through `hass.states.async_set(...)`.
 
+Charger model (v2.0.0) governs two controller behaviours, read from the config entry
+and shared via `runtime_data.power_model` (a `ChargingModel`):
+
+- **Amperage levels**: `tuya` (default) uses discrete `CHARGER_AMP_LEVELS`
+  `[6,8,10,13,16,20,24,32]`; `generic` uses 1 A steps `range(6, 33)`.
+- **Decrease sequence**: `tuya` lowers amperage with the safe stop → set → start
+  sequence (Tuya/`select` chargers misbehave on a live current change); `generic`
+  sets the lower value live, without toggling the switch.
+
 ## 5. Ownership and arbitration
 
 `custom_components/ev_smart_charger/automation_coordinator.py` is the canonical ownership plane for any automation that may start, stop, or adjust the charger.
@@ -97,11 +113,16 @@ The enforced model is:
 
 ## 6. Config and reconfiguration
 
-`custom_components/ev_smart_charger/config_flow.py` now exposes:
+`custom_components/ev_smart_charger/config_flow.py` now exposes (v2.0.0):
 
-- a 6-step initial setup flow
-- a native `async_step_reconfigure` path for mapping changes
-- a compatibility `OptionsFlow` wrapper that reuses the same validation rules
+- a 9-step initial setup flow: name → **phase_mode** → **charger_model** → entities →
+  sensors (phase-aware) → pv_forecast → notifications → external_connectors → dashboard
+- an 8-step native `async_step_reconfigure` path (entry point is phase_mode; charger
+  entities moved to `async_step_reconfigure_entities`) so existing entries can opt in
+- a matching 8-step compatibility `OptionsFlow` wrapper that reuses the same validation
+
+Missing `phase_mode` / `charger_model` keys default to `single` / `tuya`, so existing
+config entries are byte-for-byte unchanged with no migration.
 
 The canonical unique ID is `ev_charger_switch`. Duplicate charger-switch mappings abort immediately.
 
@@ -124,6 +145,7 @@ Core runtime modules:
 
 - `__init__.py`
 - `runtime.py`
+- `power_model.py` (v2.0.0 — `ChargingModel`: phase mode + charger model single source)
 - `entity_base.py`
 - `charger_controller.py`
 - `automation_coordinator.py`
@@ -156,6 +178,10 @@ Observed result:
 - `130 passed`
 - `2 warnings` from `pytest_cov`
 - total coverage `69%`
+
+v2.0.0 adds `tests/test_power_model_and_charger_model.py` (ChargingModel, const
+helpers, parametrized `AmperageCalculator`, charger-model-gated decrease) and updates
+the config-flow tests for the new 9-/8-step sequences.
 
 Release bar now met:
 

--- a/info.md
+++ b/info.md
@@ -1,2 +1,4 @@
 **EV Smart Charger — MVP**  
 Sensore di stato + select per la modalità. Base per strategie di ricarica.
+
+**v2.0.0** — Supporto opt-in **trifase** (tre sensori per produzione/consumo/prelievo, velocità bilanciata sulle tre fasi) e selettore **modello wallbox** Tuya / generica (generica = scatti da 1 A + riduzione corrente al volo). I default mantengono monofase + Tuya invariati.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,52 +9,85 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.ev_smart_charger.const import (
     DOMAIN,
     DEFAULT_BATTERY_CAPACITY,
+    CONF_CHARGER_MODEL,
     CONF_EV_CHARGER_SWITCH,
     CONF_EV_CHARGER_CURRENT,
     CONF_EV_CHARGER_STATUS,
+    CONF_PHASE_MODE,
     CONF_SOC_CAR,
     CONF_SOC_HOME,
     CONF_FV_PRODUCTION,
+    CONF_FV_PRODUCTION_L2,
+    CONF_FV_PRODUCTION_L3,
     CONF_HOME_CONSUMPTION,
+    CONF_HOME_CONSUMPTION_L2,
+    CONF_HOME_CONSUMPTION_L3,
     CONF_GRID_IMPORT,
+    CONF_GRID_IMPORT_L2,
+    CONF_GRID_IMPORT_L3,
     CONF_PV_FORECAST,
     CONF_NOTIFY_SERVICES,
     CONF_BATTERY_CAPACITY,
     CONF_CAR_OWNER,
     CONF_ENERGY_FORECAST_TARGET,
+    CHARGER_MODEL_GENERIC,
+    CHARGER_MODEL_TUYA,
+    PHASE_MODE_SINGLE,
+    PHASE_MODE_THREE,
 )
 
+
+async def _advance_mode_steps(hass: HomeAssistant, flow_id: str):
+    """v2.0.0: submit the phase_mode + charger_model steps (single + tuya).
+
+    These two steps now sit between the name step and the charger-entities step.
+    """
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_PHASE_MODE: PHASE_MODE_SINGLE}
+    )
+    assert result["step_id"] == "charger_model"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_CHARGER_MODEL: CHARGER_MODEL_TUYA}
+    )
+    return result
+
+
 async def test_form(hass: HomeAssistant):
-    """Test we get the form."""
+    """Test we get the form and can walk the full 9-step flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    # Simulate user input for the first step (Name)
+    # Step 1: name → phase_mode
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_NAME: "Test Charger"},
     )
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
-    assert result2["step_id"] == "entities"
+    assert result2["step_id"] == "phase_mode"
 
-    # Simulate user input for the second step (Charger Entities)
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
+    # Steps 2-3: phase_mode + charger_model → entities
+    result3 = await _advance_mode_steps(hass, result2["flow_id"])
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
+    assert result3["step_id"] == "entities"
+
+    # Step 4: Charger Entities → sensors
+    result4 = await hass.config_entries.flow.async_configure(
+        result3["flow_id"],
         {
             CONF_EV_CHARGER_SWITCH: "switch.charger",
             CONF_EV_CHARGER_CURRENT: "number.charger_current",
             CONF_EV_CHARGER_STATUS: "sensor.charger_status",
         },
     )
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
-    assert result3["step_id"] == "sensors"
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
+    assert result4["step_id"] == "sensors"
 
-    # Simulate user input for the third step (Sensors)
-    result4 = await hass.config_entries.flow.async_configure(
-        result3["flow_id"],
+    # Step 5: Sensors → pv_forecast
+    result5 = await hass.config_entries.flow.async_configure(
+        result4["flow_id"],
         {
             CONF_SOC_CAR: "sensor.car_soc",
             CONF_SOC_HOME: "sensor.home_soc",
@@ -63,46 +96,57 @@ async def test_form(hass: HomeAssistant):
             CONF_GRID_IMPORT: "sensor.grid",
         },
     )
-    assert result4["type"] == data_entry_flow.FlowResultType.FORM
-    assert result4["step_id"] == "pv_forecast"
+    assert result5["type"] == data_entry_flow.FlowResultType.FORM
+    assert result5["step_id"] == "pv_forecast"
 
-    # Simulate user input for the fourth step (PV Forecast)
-    result5 = await hass.config_entries.flow.async_configure(
-        result4["flow_id"],
+    # Step 6: PV Forecast → notifications
+    result6 = await hass.config_entries.flow.async_configure(
+        result5["flow_id"],
         {
             CONF_PV_FORECAST: "sensor.forecast",
         },
     )
-    assert result5["type"] == data_entry_flow.FlowResultType.FORM
-    assert result5["step_id"] == "notifications"
+    assert result6["type"] == data_entry_flow.FlowResultType.FORM
+    assert result6["step_id"] == "notifications"
 
-    # Simulate user input for the fifth step (Notifications)
+    # Step 7: Notifications → external_connectors
     with patch(
         "custom_components.ev_smart_charger.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result6 = await hass.config_entries.flow.async_configure(
-            result5["flow_id"],
+        result7 = await hass.config_entries.flow.async_configure(
+            result6["flow_id"],
             {
                 CONF_NOTIFY_SERVICES: [],
                 "car_owner": "person.test",
             },
         )
-        assert result6["type"] == data_entry_flow.FlowResultType.FORM
-        assert result6["step_id"] == "external_connectors"
+        assert result7["type"] == data_entry_flow.FlowResultType.FORM
+        assert result7["step_id"] == "external_connectors"
 
-        result7 = await hass.config_entries.flow.async_configure(
-            result6["flow_id"],
+        # Step 8: External connectors → dashboard
+        result8 = await hass.config_entries.flow.async_configure(
+            result7["flow_id"],
             {
                 CONF_BATTERY_CAPACITY: 13.5,
             },
         )
+        assert result8["type"] == data_entry_flow.FlowResultType.FORM
+        assert result8["step_id"] == "dashboard"
 
-        assert result7["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert result7["title"] == "Test Charger"
-        assert result7["data"][CONF_NAME] == "Test Charger"
-        assert result7["data"][CONF_EV_CHARGER_SWITCH] == "switch.charger"
-        
+        # Step 9: Dashboard → create entry
+        result9 = await hass.config_entries.flow.async_configure(
+            result8["flow_id"],
+            {"create_dashboard": False},
+        )
+
+        assert result9["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result9["title"] == "Test Charger"
+        assert result9["data"][CONF_NAME] == "Test Charger"
+        assert result9["data"][CONF_EV_CHARGER_SWITCH] == "switch.charger"
+        assert result9["data"][CONF_PHASE_MODE] == PHASE_MODE_SINGLE
+        assert result9["data"][CONF_CHARGER_MODEL] == CHARGER_MODEL_TUYA
+
         await hass.async_block_till_done()
         assert len(mock_setup_entry.mock_calls) == 1
 
@@ -125,6 +169,7 @@ async def test_duplicate_config_entry_aborts_on_entities_step(hass: HomeAssistan
         result["flow_id"],
         {CONF_NAME: "Duplicate Charger"},
     )
+    result = await _advance_mode_steps(hass, result["flow_id"])
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -148,6 +193,7 @@ async def test_external_connectors_validates_energy_target_entity_exists(hass: H
         result["flow_id"],
         {CONF_NAME: "Test Charger"},
     )
+    result = await _advance_mode_steps(hass, result["flow_id"])
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -189,3 +235,111 @@ async def test_external_connectors_validates_energy_target_entity_exists(hass: H
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"energy_forecast_target": "entity_not_found"}
+
+
+def _schema_keys(result) -> set[str]:
+    """Return the set of field names in a shown form's data schema."""
+    return {
+        getattr(marker, "schema", marker)
+        for marker in result["data_schema"].schema
+    }
+
+
+async def test_three_phase_generic_flow(hass: HomeAssistant):
+    """End-to-end: three-phase + generic creates an entry with all L2/L3 keys.
+
+    This is the primary path for the feature's target users — exercised through
+    the real flow (not a hand-built config dict).
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_NAME: "Three Phase"}
+    )
+    assert result["step_id"] == "phase_mode"
+
+    # phase_mode = three → charger_model
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PHASE_MODE: PHASE_MODE_THREE}
+    )
+    assert result["step_id"] == "charger_model"
+
+    # charger_model = generic → entities
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_CHARGER_MODEL: CHARGER_MODEL_GENERIC}
+    )
+    assert result["step_id"] == "entities"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EV_CHARGER_SWITCH: "switch.charger3",
+            CONF_EV_CHARGER_CURRENT: "number.charger_current",
+            CONF_EV_CHARGER_STATUS: "sensor.charger_status",
+        },
+    )
+    assert result["step_id"] == "sensors"
+
+    # The three-phase sensors form must expose all six L2/L3 power fields.
+    keys = _schema_keys(result)
+    for key in (
+        CONF_FV_PRODUCTION_L2, CONF_FV_PRODUCTION_L3,
+        CONF_HOME_CONSUMPTION_L2, CONF_HOME_CONSUMPTION_L3,
+        CONF_GRID_IMPORT_L2, CONF_GRID_IMPORT_L3,
+    ):
+        assert key in keys, f"three-phase sensors form is missing {key}"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_SOC_CAR: "sensor.car_soc",
+            CONF_SOC_HOME: "sensor.home_soc",
+            CONF_FV_PRODUCTION: "sensor.pv1",
+            CONF_FV_PRODUCTION_L2: "sensor.pv2",
+            CONF_FV_PRODUCTION_L3: "sensor.pv3",
+            CONF_HOME_CONSUMPTION: "sensor.cons1",
+            CONF_HOME_CONSUMPTION_L2: "sensor.cons2",
+            CONF_HOME_CONSUMPTION_L3: "sensor.cons3",
+            CONF_GRID_IMPORT: "sensor.grid1",
+            CONF_GRID_IMPORT_L2: "sensor.grid2",
+            CONF_GRID_IMPORT_L3: "sensor.grid3",
+        },
+    )
+    assert result["step_id"] == "pv_forecast"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PV_FORECAST: "sensor.forecast"}
+    )
+    assert result["step_id"] == "notifications"
+
+    with patch(
+        "custom_components.ev_smart_charger.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_NOTIFY_SERVICES: [], "car_owner": "person.test"},
+        )
+        assert result["step_id"] == "external_connectors"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_BATTERY_CAPACITY: 13.5}
+        )
+        assert result["step_id"] == "dashboard"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"create_dashboard": False}
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    data = result["data"]
+    assert data[CONF_PHASE_MODE] == PHASE_MODE_THREE
+    assert data[CONF_CHARGER_MODEL] == CHARGER_MODEL_GENERIC
+    # all six per-phase keys persisted
+    assert data[CONF_FV_PRODUCTION_L2] == "sensor.pv2"
+    assert data[CONF_FV_PRODUCTION_L3] == "sensor.pv3"
+    assert data[CONF_HOME_CONSUMPTION_L2] == "sensor.cons2"
+    assert data[CONF_HOME_CONSUMPTION_L3] == "sensor.cons3"
+    assert data[CONF_GRID_IMPORT_L2] == "sensor.grid2"
+    assert data[CONF_GRID_IMPORT_L3] == "sensor.grid3"

--- a/tests/test_config_flow_extended.py
+++ b/tests/test_config_flow_extended.py
@@ -11,6 +11,7 @@ from custom_components.ev_smart_charger.config_flow import EVSCConfigFlow, EVSCO
 from custom_components.ev_smart_charger.const import (
     CONF_BATTERY_CAPACITY,
     CONF_CAR_OWNER,
+    CONF_CHARGER_MODEL,
     CONF_ENERGY_FORECAST_TARGET,
     CONF_EV_CHARGER_CURRENT,
     CONF_EV_CHARGER_STATUS,
@@ -19,11 +20,14 @@ from custom_components.ev_smart_charger.const import (
     CONF_GRID_IMPORT,
     CONF_HOME_CONSUMPTION,
     CONF_NOTIFY_SERVICES,
+    CONF_PHASE_MODE,
     CONF_PV_FORECAST,
     CONF_SOC_CAR,
     CONF_SOC_HOME,
+    CHARGER_MODEL_TUYA,
     DEFAULT_BATTERY_CAPACITY,
     DOMAIN,
+    PHASE_MODE_SINGLE,
 )
 
 
@@ -63,6 +67,13 @@ async def _init_flow_to_external_connectors(hass) -> str:
         context={"source": config_entries.SOURCE_USER},
     )
     result = await hass.config_entries.flow.async_configure(result["flow_id"], name_payload)
+    # v2.0.0: phase_mode + charger_model steps now sit before charger entities.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PHASE_MODE: PHASE_MODE_SINGLE}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_CHARGER_MODEL: CHARGER_MODEL_TUYA}
+    )
     result = await hass.config_entries.flow.async_configure(result["flow_id"], entities_payload)
     result = await hass.config_entries.flow.async_configure(result["flow_id"], sensors_payload)
     result = await hass.config_entries.flow.async_configure(result["flow_id"], pv_payload)
@@ -151,7 +162,14 @@ async def test_options_flow_updates_entry_data(hass) -> None:
     flow = EVSCOptionsFlow(entry)
     flow.hass = hass
 
-    result = await flow.async_step_init(
+    # v2.0.0: init is now phase_mode → charger_model → entities → sensors → …
+    result = await flow.async_step_init({CONF_PHASE_MODE: PHASE_MODE_SINGLE})
+    assert result["step_id"] == "charger_model"
+
+    result = await flow.async_step_charger_model({CONF_CHARGER_MODEL: CHARGER_MODEL_TUYA})
+    assert result["step_id"] == "entities"
+
+    result = await flow.async_step_entities(
         {
             CONF_EV_CHARGER_SWITCH: "switch.new",
             CONF_EV_CHARGER_CURRENT: "number.new_current",
@@ -182,13 +200,16 @@ async def test_options_flow_updates_entry_data(hass) -> None:
     )
     assert result["step_id"] == "external_connectors"
 
+    result = await flow.async_step_external_connectors(
+        {
+            CONF_BATTERY_CAPACITY: 15.0,
+            CONF_ENERGY_FORECAST_TARGET: "number.energy_target",
+        }
+    )
+    assert result["step_id"] == "dashboard"
+
     with patch.object(hass.config_entries, "async_update_entry") as update_entry:
-        result = await flow.async_step_external_connectors(
-            {
-                CONF_BATTERY_CAPACITY: 15.0,
-                CONF_ENERGY_FORECAST_TARGET: "number.energy_target",
-            }
-        )
+        result = await flow.async_step_dashboard({"create_dashboard": False})
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     update_entry.assert_called_once()
@@ -295,7 +316,16 @@ async def test_reconfigure_flow_updates_entry_data(hass) -> None:
     flow.context = {"entry_id": entry.entry_id}
     flow._reconfigure_entry = entry
 
-    result = await flow.async_step_reconfigure(
+    # v2.0.0: reconfigure entry point is now phase_mode → charger_model → entities → sensors → …
+    result = await flow.async_step_reconfigure({CONF_PHASE_MODE: PHASE_MODE_SINGLE})
+    assert result["step_id"] == "reconfigure_charger_model"
+
+    result = await flow.async_step_reconfigure_charger_model(
+        {CONF_CHARGER_MODEL: CHARGER_MODEL_TUYA}
+    )
+    assert result["step_id"] == "reconfigure_entities"
+
+    result = await flow.async_step_reconfigure_entities(
         {
             CONF_EV_CHARGER_SWITCH: "switch.new",
             CONF_EV_CHARGER_CURRENT: "number.new_current",
@@ -328,13 +358,16 @@ async def test_reconfigure_flow_updates_entry_data(hass) -> None:
     )
     assert result["step_id"] == "reconfigure_external_connectors"
 
+    result = await flow.async_step_reconfigure_external_connectors(
+        {
+            CONF_BATTERY_CAPACITY: 15.0,
+            CONF_ENERGY_FORECAST_TARGET: "number.energy_target",
+        }
+    )
+    assert result["step_id"] == "reconfigure_dashboard"
+
     with patch.object(hass.config_entries, "async_update_entry") as update_entry:
-        result = await flow.async_step_reconfigure_external_connectors(
-            {
-                CONF_BATTERY_CAPACITY: 15.0,
-                CONF_ENERGY_FORECAST_TARGET: "number.energy_target",
-            }
-        )
+        result = await flow.async_step_reconfigure_dashboard({"create_dashboard": False})
 
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
@@ -366,7 +399,11 @@ async def test_reconfigure_flow_rejects_duplicate_switch(hass) -> None:
     flow.context = {"entry_id": target_entry.entry_id}
     flow._reconfigure_entry = target_entry
 
-    result = await flow.async_step_reconfigure(
+    # v2.0.0: the duplicate-switch guard now lives in reconfigure_entities,
+    # reached after the phase_mode + charger_model steps.
+    await flow.async_step_reconfigure({CONF_PHASE_MODE: PHASE_MODE_SINGLE})
+    await flow.async_step_reconfigure_charger_model({CONF_CHARGER_MODEL: CHARGER_MODEL_TUYA})
+    result = await flow.async_step_reconfigure_entities(
         {
             CONF_EV_CHARGER_SWITCH: "switch.duplicate",
             CONF_EV_CHARGER_CURRENT: "number.new_current",

--- a/tests/test_power_model_and_charger_model.py
+++ b/tests/test_power_model_and_charger_model.py
@@ -1,0 +1,213 @@
+"""Tests for the v2.0.0 phase-mode + charger-model logic.
+
+Covers the single source of truth (ChargingModel / const helpers), the
+parametrized AmperageCalculator level steppers, and the charger-model-gated
+amperage-decrease behaviour in ChargerController.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.ev_smart_charger.const import (
+    CHARGER_AMP_LEVELS,
+    CHARGER_MODEL_GENERIC,
+    CHARGER_MODEL_TUYA,
+    CONF_CHARGER_MODEL,
+    CONF_EV_CHARGER_CURRENT,
+    CONF_EV_CHARGER_SWITCH,
+    CONF_FV_PRODUCTION,
+    CONF_FV_PRODUCTION_L2,
+    CONF_FV_PRODUCTION_L3,
+    CONF_GRID_IMPORT,
+    CONF_GRID_IMPORT_L2,
+    CONF_GRID_IMPORT_L3,
+    CONF_HOME_CONSUMPTION,
+    CONF_HOME_CONSUMPTION_L2,
+    CONF_HOME_CONSUMPTION_L3,
+    CONF_PHASE_MODE,
+    GENERIC_AMP_LEVELS,
+    PHASE_MODE_THREE,
+    VOLTAGE_EU,
+    get_amp_levels,
+    get_effective_voltage,
+    get_phase_count,
+    is_three_phase,
+)
+from custom_components.ev_smart_charger.charger_controller import ChargerController
+from custom_components.ev_smart_charger.power_model import ChargingModel
+from custom_components.ev_smart_charger.utils.amperage_helper import AmperageCalculator
+
+
+SINGLE_CONFIG = {
+    CONF_FV_PRODUCTION: "sensor.pv",
+    CONF_HOME_CONSUMPTION: "sensor.cons",
+    CONF_GRID_IMPORT: "sensor.grid",
+}
+
+THREE_CONFIG = {
+    CONF_PHASE_MODE: PHASE_MODE_THREE,
+    CONF_CHARGER_MODEL: CHARGER_MODEL_GENERIC,
+    CONF_FV_PRODUCTION: "sensor.pv1",
+    CONF_FV_PRODUCTION_L2: "sensor.pv2",
+    CONF_FV_PRODUCTION_L3: "sensor.pv3",
+    CONF_HOME_CONSUMPTION: "sensor.cons1",
+    CONF_HOME_CONSUMPTION_L2: "sensor.cons2",
+    CONF_HOME_CONSUMPTION_L3: "sensor.cons3",
+    CONF_GRID_IMPORT: "sensor.grid1",
+    CONF_GRID_IMPORT_L2: "sensor.grid2",
+    CONF_GRID_IMPORT_L3: "sensor.grid3",
+}
+
+
+# ----------------------------------------------------------------------------
+# const helpers + ChargingModel (pure)
+# ----------------------------------------------------------------------------
+
+
+def test_const_helpers_default_single_tuya():
+    """Empty config = single-phase, 230 V, Tuya levels (unchanged behaviour)."""
+    assert is_three_phase({}) is False
+    assert get_phase_count({}) == 1
+    assert get_effective_voltage({}) == VOLTAGE_EU  # 230
+    assert get_amp_levels({}) == CHARGER_AMP_LEVELS
+
+
+def test_const_helpers_three_phase_generic():
+    """Three-phase = 690 V; generic model = 1 A levels."""
+    assert is_three_phase(THREE_CONFIG) is True
+    assert get_phase_count(THREE_CONFIG) == 3
+    assert get_effective_voltage(THREE_CONFIG) == VOLTAGE_EU * 3  # 690
+    assert get_amp_levels(THREE_CONFIG) == GENERIC_AMP_LEVELS
+    assert GENERIC_AMP_LEVELS[0] == 6 and GENERIC_AMP_LEVELS[-1] == 32
+    assert 7 in GENERIC_AMP_LEVELS and 11 in GENERIC_AMP_LEVELS  # 1 A granularity
+
+
+def test_charging_model_single():
+    model = ChargingModel.from_config(SINGLE_CONFIG)
+    assert model.phase_count == 1
+    assert model.effective_voltage == 230
+    assert model.amp_levels == CHARGER_AMP_LEVELS
+    assert model.charger_model == CHARGER_MODEL_TUYA
+    assert model.production_entities() == ["sensor.pv"]
+    assert model.grid_import_entities() == ["sensor.grid"]
+    # 3680 W single-phase → 16 A
+    assert model.watts_to_amps(3680) == pytest.approx(16.0)
+
+
+def test_charging_model_three_phase():
+    model = ChargingModel.from_config(THREE_CONFIG)
+    assert model.phase_count == 3
+    assert model.effective_voltage == 690
+    assert model.amp_levels == GENERIC_AMP_LEVELS
+    assert model.production_entities() == ["sensor.pv1", "sensor.pv2", "sensor.pv3"]
+    assert model.consumption_entities() == ["sensor.cons1", "sensor.cons2", "sensor.cons3"]
+    assert model.grid_import_entities() == ["sensor.grid1", "sensor.grid2", "sensor.grid3"]
+    # 11040 W total / 690 → 16 A per phase
+    assert model.watts_to_amps(11040) == pytest.approx(16.0)
+    # labelled list gains Ln suffixes (9 power sensors in three-phase)
+    labelled = model.labelled_power_entities()
+    assert len(labelled) == 9
+    assert ("sensor.pv2", "Solar Production L2") in labelled
+
+
+# ----------------------------------------------------------------------------
+# AmperageCalculator parametrization
+# ----------------------------------------------------------------------------
+
+
+def test_amperage_calculator_default_is_tuya():
+    """No amp_levels arg → Tuya discrete behaviour preserved."""
+    assert AmperageCalculator.get_next_level_down(16) == 13
+    assert AmperageCalculator.get_next_level_up(13, 32) == 16
+    assert AmperageCalculator.get_next_level_down(6) == 0  # at minimum → stop
+
+
+def test_amperage_calculator_generic_levels():
+    """Generic 1 A levels step by one ampere."""
+    assert AmperageCalculator.get_next_level_down(11, GENERIC_AMP_LEVELS) == 10
+    assert AmperageCalculator.get_next_level_up(11, 32, GENERIC_AMP_LEVELS) == 12
+    assert AmperageCalculator.get_next_level_down(6, GENERIC_AMP_LEVELS) == 0
+    assert AmperageCalculator.get_next_level_up(31, 32, GENERIC_AMP_LEVELS) == 32
+
+
+# ----------------------------------------------------------------------------
+# Power readers (need hass for state)
+# ----------------------------------------------------------------------------
+
+
+async def test_read_production_sums_phases(hass):
+    """Three-phase production = sum of the three phase sensors."""
+    hass.states.async_set("sensor.pv1", "1000")
+    hass.states.async_set("sensor.pv2", "1500")
+    hass.states.async_set("sensor.pv3", "500")
+    model = ChargingModel.from_config(THREE_CONFIG)
+    assert model.read_production(hass) == pytest.approx(3000.0)
+
+
+async def test_read_production_single_phase_unchanged(hass):
+    """Single-phase production reads exactly the one configured sensor."""
+    hass.states.async_set("sensor.pv", "2200")
+    model = ChargingModel.from_config(SINGLE_CONFIG)
+    assert model.read_production(hass) == pytest.approx(2200.0)
+
+
+# ----------------------------------------------------------------------------
+# Charger-model-gated decrease (the headline behaviour)
+# ----------------------------------------------------------------------------
+
+
+def _make_controller(hass, charger_model: str) -> ChargerController:
+    config = {
+        CONF_EV_CHARGER_SWITCH: "switch.charger",
+        CONF_EV_CHARGER_CURRENT: "number.charger_current",
+        CONF_CHARGER_MODEL: charger_model,
+    }
+    return ChargerController(hass, "entry_id", config)
+
+
+async def test_tuya_decrease_uses_stop_set_start(hass):
+    """Tuya: lowering amperage turns the charger off then on (safe sequence)."""
+    controller = _make_controller(hass, CHARGER_MODEL_TUYA)
+    controller._is_on = True
+    controller._current_amperage = 16
+    controller._refresh_state = AsyncMock()
+    controller._call_service = AsyncMock()
+    controller._set_amperage_internal = AsyncMock()
+
+    op = await controller._set_amperage_unlocked(10)
+
+    assert op == "adjust_down"
+    # turn_off then turn_on were both issued
+    services = [c.args[1] for c in controller._call_service.await_args_list]
+    assert "turn_off" in services
+    assert "turn_on" in services
+
+
+async def test_generic_decrease_is_live_no_stop(hass):
+    """Generic: lowering amperage sets the value live, never stops the charger."""
+    controller = _make_controller(hass, CHARGER_MODEL_GENERIC)
+    controller._is_on = True
+    controller._current_amperage = 16
+    controller._refresh_state = AsyncMock()
+    controller._call_service = AsyncMock()
+    controller._set_amperage_internal = AsyncMock()
+
+    op = await controller._set_amperage_unlocked(10)
+
+    assert op == "set_amperage"
+    controller._set_amperage_internal.assert_awaited_once_with(10)
+    # the charger switch was never toggled
+    services = [c.args[1] for c in controller._call_service.await_args_list]
+    assert "turn_off" not in services
+    assert "turn_on" not in services
+
+
+def test_controller_normalizes_to_model_levels(hass):
+    """Generic snaps to the nearest integer; Tuya snaps to discrete levels."""
+    tuya = _make_controller(hass, CHARGER_MODEL_TUYA)
+    generic = _make_controller(hass, CHARGER_MODEL_GENERIC)
+    # 11 A: Tuya → nearest discrete (10), generic → 11 (valid level)
+    assert tuya._normalize_target_amps(11) == 10
+    assert generic._normalize_target_amps(11) == 11


### PR DESCRIPTION
## 🌍 EV Smart Charger goes universal

**MAJOR release (v2.0.0).** This integration now adapts to *any* solar + EV installation on the market — single-phase **or** three-phase, Tuya **or** any other wallbox, cloud **or** local — while remaining **100% backward compatible**.

> **Upgrading changes nothing for existing users.** Defaults stay **single-phase + Tuya**, no migration, no behaviour change. The new capabilities are strictly opt-in via the config flow / Reconfigure.

### What's new (both opt-in)

**Phase mode — `single` (default) | `three`**
- Three-phase maps **three sensors each** for production / home-consumption / grid-import (L1 reuses the existing key; L2/L3 are new), summed together.
- Watt→amp conversion uses the effective voltage `phase_count × 230 V` (690 V in 3φ), so per-phase thresholds and amp levels stay valid downstream (`P = 3·V·I`). SOC sensors stay single.

**Charger model — `tuya` (default) | `generic`**
- `tuya`: discrete levels `[6,8,10,13,16,20,24,32] A`, safe stop→set→start on decrease.
- `generic`: **1 A steps** (6–32) and **live current decrease without stopping** the charger — for any non-Tuya wallbox exposing current as a `number` entity.

### Architecture
- New `power_model.py` (`ChargingModel`) — single source of truth, built once and shared via `runtime_data.power_model`.
- Config flow 7→9 steps (`phase_mode`, `charger_model`); reconfigure & options mirrored to 8 steps. Full EN/IT/NL i18n.
- Dashboard sums per-phase sensors for the power tiles and derives charging power at 690 V in three-phase.

### Compatibility & safety
- Missing `phase_mode` / `charger_model` keys resolve to `single` / `tuya` via `.get()` — no config-entry migration. Entity counts unchanged.
- ⚠️ In three-phase every amperage setting is per-phase, so it means ~3× the power (16 A ≈ 11 kW; min ~4.1 kW) — documented in the flow + README.

### Tests
- New `tests/test_power_model_and_charger_model.py` (ChargingModel, const helpers, parametrized AmperageCalculator, charger-model-gated decrease) + an end-to-end three-phase/generic config-flow test.
- Config-flow tests updated for the new 9-/8-step sequences.

Resolves #5 · implements [discussion #18](https://github.com/antbald/ha-ev-smart-charger/discussions/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)