### PR TITLE
v2.1.1 — tolerate user-disabled helper entities (#22), supersedes #25

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -756,6 +756,29 @@ async def _set_amperage(self, target_amperage: int):
 
 ## Version History
 
+### v2.1.1 (2026-06-01)
+**FIX: Tolerate user-disabled helper entities at startup ([issue #22](https://github.com/antbald/ha-ev-smart-charger/issues/22) — xion2000)**
+
+**Problem**: disabling *any* helper entity in Home Assistant (e.g. the Night Smart Charge controls + daily SOC targets a retired user on no overnight tariff doesn't need) stopped the integration from initializing after a HA restart, with the opaque `ConfigEntryNotReady` "Timed out while waiting for … registration". Re-enabling the entities fixed it.
+
+**Root cause**: the Phase 1 barrier in [`__init__.py`](custom_components/ev_smart_charger/__init__.py) waits on `runtime_data.registration_event`, which only fires when `registered_entity_count >= expected_entity_count` (66 / 52 PV-only). HA skips `async_added_to_hass` ([entity_base.py:51](custom_components/ev_smart_charger/entity_base.py:51)) for disabled entities, so the counter never reaches the target → 10 s `asyncio.wait_for` times out → `ConfigEntryNotReady`.
+
+**Fix**: new `_async_wait_for_helper_registration()` replaces the inline `try/except`. On timeout it reconciles against the **entity registry** (`disabled_by != None`):
+- `registered + disabled >= expected` → user consciously disabled them. Log a WARNING, surface a Home Assistant **Repairs** entry (`translation_key="disabled_helpers"`, severity WARNING, EN/IT/NL), proceed in degraded mode (`state_helper` already defaults safely on `None`/`unknown`/`unavailable`). The Repairs entry clears on the next clean boot.
+- real shortfall → log an ERROR with the count of genuinely missing entities and raise `ConfigEntryNotReady` so HA retries.
+
+This is a faithful re-implementation of the never-merged v1.11.2 work (PR #25, which was stranded ~10 versions behind master and whose only tester likely mis-installed a branch download instead of a release). The unique-id matcher (`_entity_key_from_unique_id`, format `{DOMAIN}_{entry_id}_{key}` per [entity_base.py:31](custom_components/ev_smart_charger/entity_base.py:31)) was re-verified against the real format.
+
+**Coupling note** added next to `TOTAL_INTEGRATION_ENTITIES` in [const.py](custom_components/ev_smart_charger/const.py): the disabled-helper tolerance assumes the constant equals the number of entities created when nothing is disabled; if it drifts above reality (cf. v1.6.20), a single disabled entity would silently tip the count back into a hard `ConfigEntryNotReady`.
+
+**Tests** ([tests/test_integration_setup.py](tests/test_integration_setup.py)): unit tests for `_entity_key_from_unique_id` (accept valid, reject foreign/cross-entry); a regression test mirroring xion2000's setup that builds **real `entity_registry` entries with `RegistryEntryDisabler.USER`**, fires the timeout, and asserts `async_setup_entry` returns `True` + a `disabled_helpers` Repairs issue exists; and a genuine-shortfall test that still raises `ConfigEntryNotReady` with no Repairs issue. Full suite green except the 19 pre-existing environment-only baseline failures (identical on clean master).
+
+**Files**: `__init__.py` (helpers + Phase 1 call), `const.py` (coupling comment + VERSION), `manifest.json`, `strings.json` + `translations/{en,it,nl}.json` (new `issues.disabled_helpers` block), `tests/test_integration_setup.py`. `VERSION = "2.1.1"`.
+
+**Backward compatible**: zero schema / entity / config-flow changes. Installs with all helpers enabled hit the unchanged happy path. **Upgrade priority**: 🟢 RECOMMENDED for anyone who has disabled helper entities; ⚪ NO-OP otherwise.
+
+---
+
 ### v2.1.0 (2026-05-31)
 **Battery-discharge masking detection for Hybrid Inverter Mode + Solar-Surplus deadband buffer ([issue #29](https://github.com/antbald/ha-ev-smart-charger/issues/29), DJm00n)**
 

--- a/custom_components/ev_smart_charger/__init__.py
+++ b/custom_components/ev_smart_charger/__init__.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: no cover - compatibility branch for older HA core
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_time_interval,
@@ -22,6 +23,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_CREATE_DASHBOARD,
     DEFAULT_CREATE_DASHBOARD,
+    DEFAULT_NAME,
     DOMAIN,
     FRONTEND_CARD_FILENAME,
     FRONTEND_URL_BASE,
@@ -108,6 +110,148 @@ async def _async_cleanup_partial_setup(runtime_data: EVSCRuntimeData) -> None:
             _LOGGER.exception("Failed partial setup cleanup for %s", label)
 
 
+DISABLED_HELPERS_ISSUE_PREFIX = "disabled_helpers"
+
+
+def _entity_key_from_unique_id(unique_id: str, entry_id: str) -> str | None:
+    """Extract the logical helper key from an EVSC entity unique_id.
+
+    Format is ``{DOMAIN}_{entry_id}_{key}`` — see entity_base.py:31.
+    Returns None if the unique_id does not match the EVSC pattern (e.g. it
+    belongs to a different integration sharing the registry, or a different
+    EVSC config entry).
+    """
+    prefix = f"{DOMAIN}_{entry_id}_"
+    if not unique_id.startswith(prefix):
+        return None
+    return unique_id[len(prefix):]
+
+
+def _collect_disabled_helper_keys(hass: HomeAssistant, entry_id: str) -> list[str]:
+    """Return logical keys of EVSC helper entities disabled in the registry.
+
+    "Disabled" here means ``disabled_by is not None`` for any reason
+    (USER, INTEGRATION, HASS, CONFIG_ENTRY). Home Assistant skips
+    ``async_added_to_hass`` for all of these, so they all break the
+    registration barrier in the same way.
+    """
+    ent_reg = er.async_get(hass)
+    disabled_keys: list[str] = []
+    for registry_entry in ent_reg.entities.values():
+        if registry_entry.config_entry_id != entry_id:
+            continue
+        if registry_entry.disabled_by is None:
+            continue
+        key = _entity_key_from_unique_id(registry_entry.unique_id, entry_id)
+        if key is not None:
+            disabled_keys.append(key)
+    return disabled_keys
+
+
+@callback
+def _refresh_disabled_helpers_issue(
+    hass: HomeAssistant, entry: ConfigEntry, disabled_keys: list[str]
+) -> None:
+    """Create or clear the Repairs entry for user-disabled helper entities."""
+    issue_id = f"{DISABLED_HELPERS_ISSUE_PREFIX}_{entry.entry_id}"
+    if not disabled_keys:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+        return
+
+    preview_limit = 8
+    sorted_keys = sorted(disabled_keys)
+    preview = ", ".join(sorted_keys[:preview_limit])
+    if len(sorted_keys) > preview_limit:
+        preview = f"{preview}, …"
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="disabled_helpers",
+        translation_placeholders={
+            "count": str(len(disabled_keys)),
+            "entities": preview,
+            "entry_title": entry.title or DEFAULT_NAME,
+        },
+        learn_more_url="https://github.com/antbald/ha-ev-smart-charger/issues/22",
+    )
+
+
+async def _async_wait_for_helper_registration(
+    hass: HomeAssistant, entry: ConfigEntry, runtime_data: EVSCRuntimeData
+) -> None:
+    """Wait for helper entities to register; tolerate user-disabled ones.
+
+    Behaviour (issue #22 — reported by xion2000):
+      * Normal case — all helpers register within the timeout → return and
+        clear any stale Repairs entry left from a previous boot.
+      * User disabled some helpers — they never call ``async_added_to_hass``
+        (entity_base.py:51), so the barrier never fires by itself. Once the
+        timeout elapses, count ``disabled_by != None`` entities via the entity
+        registry: if ``registered + disabled >= expected`` the user
+        consciously turned them off, so log a warning, surface a Repairs
+        issue, and proceed in degraded mode (state_helper already defaults
+        safely on None/unknown/unavailable).
+      * Genuinely missing helpers (platform failure, programming error) →
+        raise ``ConfigEntryNotReady`` so HA retries setup later.
+
+    NOTE: the disabled-helper tolerance assumes ``expected_entity_count``
+    (TOTAL_INTEGRATION_ENTITIES / _NO_BATTERY in const.py) matches the actual
+    number of entities created when nothing is disabled. If that constant
+    drifts above reality (cf. the v1.6.20 regression), a single disabled
+    entity would silently tip ``registered + disabled`` below ``expected`` and
+    turn this tolerant path back into a hard ConfigEntryNotReady.
+    """
+    try:
+        await asyncio.wait_for(
+            runtime_data.registration_event.wait(), timeout=10
+        )
+        # Clean state — drop any stale Repairs entry left from a previous run.
+        _refresh_disabled_helpers_issue(hass, entry, [])
+        return
+    except TimeoutError as err:
+        disabled_keys = _collect_disabled_helper_keys(hass, entry.entry_id)
+        registered = runtime_data.registered_entity_count
+        expected = runtime_data.expected_entity_count
+        accounted = registered + len(disabled_keys)
+
+        if accounted >= expected:
+            _LOGGER.warning(
+                "⚠️  %d helper entit%s disabled by the user (registered=%d, "
+                "disabled=%d, expected=%d) — proceeding in degraded mode. "
+                "Disabled: %s",
+                len(disabled_keys),
+                "y" if len(disabled_keys) == 1 else "ies",
+                registered,
+                len(disabled_keys),
+                expected,
+                ", ".join(sorted(disabled_keys)),
+            )
+            _refresh_disabled_helpers_issue(hass, entry, disabled_keys)
+            return
+
+        missing = expected - accounted
+        _LOGGER.error(
+            "❌ %d EV Smart Charger helper entit%s never registered "
+            "(registered=%d, disabled=%d, expected=%d). This is not a "
+            "user-disabled-entity situation — retrying setup.",
+            missing,
+            "y" if missing == 1 else "ies",
+            registered,
+            len(disabled_keys),
+            expected,
+        )
+        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        entry.runtime_data = None
+        raise ConfigEntryNotReady(
+            "Timed out while waiting for EV Smart Charger helper entities "
+            "registration"
+        ) from err
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up EV Smart Charger from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -147,15 +291,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _LOGGER.info(f"✅ Platforms registered: {', '.join(PLATFORMS)}")
 
-    # Wait for entity registration barrier
-    try:
-        await asyncio.wait_for(runtime_data.registration_event.wait(), timeout=10)
-    except TimeoutError as err:
-        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-        entry.runtime_data = None
-        raise ConfigEntryNotReady(
-            "Timed out while waiting for EV Smart Charger helper entities registration"
-        ) from err
+    # Wait for entity registration barrier (tolerates user-disabled helpers,
+    # issue #22). Raises ConfigEntryNotReady on a genuine shortfall.
+    await _async_wait_for_helper_registration(hass, entry, runtime_data)
 
     _LOGGER.info(
         "✅ %s helper entities registered",

--- a/custom_components/ev_smart_charger/const.py
+++ b/custom_components/ev_smart_charger/const.py
@@ -2,7 +2,7 @@
 
 # ========== INTEGRATION METADATA ==========
 DOMAIN = "ev_smart_charger"
-VERSION = "2.1.0"
+VERSION = "2.1.1"
 DEFAULT_NAME = "EV Smart Charger"
 FRONTEND_URL_BASE = "/api/ev_smart_charger/frontend"
 FRONTEND_CARD_FILENAME = "ev-smart-charger-dashboard.js"
@@ -346,6 +346,11 @@ HYBRID_STATE_HARD_EXIT = "HARD_EXIT"
 # v1.8.0 set the baseline to 64 (added 6 Hybrid Mode entities). v1.11.9 added
 # 1 sensor (evsc_night_session_state) → 65. v2.1.0 (issue #29) adds 1 battery-only
 # number (evsc_max_battery_discharge_for_ev) → 66.
+# COUPLING (issue #22): the disabled-helper tolerance in
+# __init__._async_wait_for_helper_registration assumes this equals the number
+# of entities actually created when nothing is disabled. If it drifts above
+# reality (cf. v1.6.20), a single user-disabled entity turns the tolerant
+# startup path back into a hard ConfigEntryNotReady. Keep this in sync.
 TOTAL_INTEGRATION_ENTITIES = 66
 # Verified count (v1.11.9): 52 entities when running in PV-only mode.
 # Unchanged in v2.1.0: the new number is battery-only (skipped in PV-only mode).

--- a/custom_components/ev_smart_charger/manifest.json
+++ b/custom_components/ev_smart_charger/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/antbald/ha-ev-smart-charger/issues",
   "requirements": [],
-  "version": "2.1.0"
+  "version": "2.1.1"
 }

--- a/custom_components/ev_smart_charger/strings.json
+++ b/custom_components/ev_smart_charger/strings.json
@@ -587,5 +587,11 @@
         "generic": "Generic (1 A steps)"
       }
     }
+  },
+  "issues": {
+    "disabled_helpers": {
+      "title": "Some EV Smart Charger helper entities are disabled",
+      "description": "{count} helper entit(y/ies) of \"{entry_title}\" are disabled in Home Assistant ({entities}). EV Smart Charger started in degraded mode, using safe defaults for the disabled values. This is tolerated, but disabling entities is not a supported way to turn features off. Re-enable them under Settings → Devices & services, or wait for per-feature opt-out toggles (issue #24). This notice clears automatically on the next clean start."
+    }
   }
 }

--- a/custom_components/ev_smart_charger/translations/en.json
+++ b/custom_components/ev_smart_charger/translations/en.json
@@ -587,5 +587,11 @@
         "generic": "Generic (1 A steps)"
       }
     }
+  },
+  "issues": {
+    "disabled_helpers": {
+      "title": "Some EV Smart Charger helper entities are disabled",
+      "description": "{count} helper entit(y/ies) of \"{entry_title}\" are disabled in Home Assistant ({entities}). EV Smart Charger started in degraded mode, using safe defaults for the disabled values. This is tolerated, but disabling entities is not a supported way to turn features off. Re-enable them under Settings → Devices & services, or wait for per-feature opt-out toggles (issue #24). This notice clears automatically on the next clean start."
+    }
   }
 }

--- a/custom_components/ev_smart_charger/translations/it.json
+++ b/custom_components/ev_smart_charger/translations/it.json
@@ -587,5 +587,11 @@
         "generic": "Generica (scatti da 1 A)"
       }
     }
+  },
+  "issues": {
+    "disabled_helpers": {
+      "title": "Alcune entità helper di EV Smart Charger sono disabilitate",
+      "description": "{count} entità helper di \"{entry_title}\" risultano disabilitate in Home Assistant ({entities}). EV Smart Charger è partito in modalità degradata, usando valori predefiniti sicuri per quelle disabilitate. È tollerato, ma disabilitare le entità non è il modo supportato per spegnere le funzioni. Riabilitale in Impostazioni → Dispositivi e servizi, oppure attendi gli interruttori di opt-out per singola funzione (issue #24). Questo avviso si cancella da solo al prossimo avvio pulito."
+    }
   }
 }

--- a/custom_components/ev_smart_charger/translations/nl.json
+++ b/custom_components/ev_smart_charger/translations/nl.json
@@ -587,5 +587,11 @@
         "generic": "Generiek (stappen van 1 A)"
       }
     }
+  },
+  "issues": {
+    "disabled_helpers": {
+      "title": "Sommige helper-entiteiten van EV Smart Charger zijn uitgeschakeld",
+      "description": "{count} helper-entiteit(en) van \"{entry_title}\" zijn uitgeschakeld in Home Assistant ({entities}). EV Smart Charger is in gedegradeerde modus gestart en gebruikt veilige standaardwaarden voor de uitgeschakelde waarden. Dit wordt getolereerd, maar entiteiten uitschakelen is geen ondersteunde manier om functies uit te zetten. Schakel ze weer in via Instellingen → Apparaten en diensten, of wacht op opt-out-schakelaars per functie (issue #24). Deze melding verdwijnt automatisch bij de volgende schone start."
+    }
   }
 }

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -6,10 +6,13 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ev_smart_charger import (
+    DISABLED_HELPERS_ISSUE_PREFIX,
     _async_register_frontend,
+    _entity_key_from_unique_id,
     async_setup_entry,
     async_unload_entry,
 )
@@ -269,3 +272,177 @@ async def test_async_unload_entry_removes_components_in_reverse_order(hass) -> N
     assert result is True
     assert call_order == ["solar", "blocker", "boost", "night", "priority", "diagnostic", "log", "soc"]
     assert entry.runtime_data is None
+
+
+# ── issue #22: tolerate user-disabled helper entities ────────────────────────
+
+
+def test_entity_key_from_unique_id_matches_evsc_pattern() -> None:
+    """Valid EVSC unique_ids yield their logical key."""
+    assert (
+        _entity_key_from_unique_id(
+            f"{DOMAIN}_entry-1_evsc_forza_ricarica", "entry-1"
+        )
+        == "evsc_forza_ricarica"
+    )
+    # entry_id may itself contain underscores (ULID does not, but be robust).
+    assert (
+        _entity_key_from_unique_id(f"{DOMAIN}_abc_123_evsc_x", "abc_123")
+        == "evsc_x"
+    )
+
+
+def test_entity_key_from_unique_id_rejects_foreign_unique_id() -> None:
+    """unique_ids from other integrations or other entries are rejected."""
+    # Different integration.
+    assert _entity_key_from_unique_id("other_entry-1_evsc_x", "entry-1") is None
+    # Same integration, different config entry.
+    assert (
+        _entity_key_from_unique_id(f"{DOMAIN}_entry-2_evsc_x", "entry-1") is None
+    )
+
+
+async def test_async_setup_entry_proceeds_with_user_disabled_helpers(hass) -> None:
+    """User-disabled helpers must not block setup; a Repairs issue is raised."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_entry_data(), entry_id="entry-1")
+    entry.add_to_hass(hass)
+    _stub_http(hass)
+
+    # Mirror xion2000's setup: 7 helpers disabled by the user. They live in the
+    # entity registry with disabled_by=USER and never call async_added_to_hass.
+    disabled_keys = [
+        "evsc_night_smart_charge_enabled",
+        "evsc_ev_min_soc_monday",
+        "evsc_ev_min_soc_tuesday",
+        "evsc_ev_min_soc_wednesday",
+        "evsc_ev_min_soc_thursday",
+        "evsc_ev_min_soc_friday",
+        "evsc_night_charge_time",
+    ]
+    ent_reg = er.async_get(hass)
+    for key in disabled_keys:
+        ent_reg.async_get_or_create(
+            "number",
+            DOMAIN,
+            f"{DOMAIN}_{entry.entry_id}_{key}",
+            config_entry=entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+
+    charger_controller = _component("charger")
+    ev_soc_monitor = _component("soc")
+    priority_balancer = _component("priority")
+    night_smart_charge = _component("night")
+    boost_charge = _component("boost")
+    smart_blocker = _component("blocker")
+    solar_surplus = _component("solar")
+    log_manager = _component("log")
+    diagnostic_manager = _component("diagnostic")
+    coordinator = SimpleNamespace()
+
+    async def forward_setups(config_entry, platforms):
+        # Only the enabled helpers register; the barrier never fires by itself.
+        runtime_data = config_entry.runtime_data
+        runtime_data.registered_entity_count = (
+            TOTAL_INTEGRATION_ENTITIES - len(disabled_keys)
+        )
+
+    async def timeout_wait_for(awaitable, timeout):
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()
+        raise TimeoutError
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=forward_setups,
+        autospec=True,
+    ), patch(
+        "custom_components.ev_smart_charger.asyncio.wait_for",
+        side_effect=timeout_wait_for,
+    ), patch(
+        "custom_components.ev_smart_charger.ChargerController",
+        return_value=charger_controller,
+    ), patch(
+        "custom_components.ev_smart_charger.EVSOCMonitor",
+        return_value=ev_soc_monitor,
+    ), patch(
+        "custom_components.ev_smart_charger.AutomationCoordinator",
+        return_value=coordinator,
+    ), patch(
+        "custom_components.ev_smart_charger.DiagnosticManager",
+        return_value=diagnostic_manager,
+    ), patch(
+        "custom_components.ev_smart_charger.PriorityBalancer",
+        return_value=priority_balancer,
+    ), patch(
+        "custom_components.ev_smart_charger.NightSmartCharge",
+        return_value=night_smart_charge,
+    ), patch(
+        "custom_components.ev_smart_charger.BoostCharge",
+        return_value=boost_charge,
+    ), patch(
+        "custom_components.ev_smart_charger.SmartChargerBlocker",
+        return_value=smart_blocker,
+    ), patch(
+        "custom_components.ev_smart_charger.SolarSurplusAutomation",
+        return_value=solar_surplus,
+    ), patch(
+        "custom_components.ev_smart_charger.LogManager",
+        return_value=log_manager,
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+
+    # A Repairs entry must surface, listing the disabled helpers.
+    issue_reg = ir.async_get(hass)
+    issue = issue_reg.async_get_issue(
+        DOMAIN, f"{DISABLED_HELPERS_ISSUE_PREFIX}_{entry.entry_id}"
+    )
+    assert issue is not None
+    assert issue.translation_key == "disabled_helpers"
+    assert issue.translation_placeholders["count"] == str(len(disabled_keys))
+
+
+async def test_async_setup_entry_raises_not_ready_on_real_shortfall(hass) -> None:
+    """A genuine shortfall (no disabled entities) still raises ConfigEntryNotReady."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_entry_data(), entry_id="entry-1")
+    entry.add_to_hass(hass)
+    _stub_http(hass)
+
+    async def forward_setups(config_entry, platforms):
+        # Far fewer than expected register and nothing is disabled → real bug.
+        config_entry.runtime_data.registered_entity_count = 3
+
+    async def timeout_wait_for(awaitable, timeout):
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()
+        raise TimeoutError
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=forward_setups,
+        autospec=True,
+    ), patch(
+        "custom_components.ev_smart_charger.asyncio.wait_for",
+        side_effect=timeout_wait_for,
+    ), patch.object(
+        hass.config_entries,
+        "async_unload_platforms",
+        AsyncMock(return_value=True),
+    ):
+        with pytest.raises(ConfigEntryNotReady):
+            await async_setup_entry(hass, entry)
+
+    # No Repairs entry on the genuine-shortfall path.
+    issue_reg = ir.async_get(hass)
+    assert (
+        issue_reg.async_get_issue(
+            DOMAIN, f"{DISABLED_HELPERS_ISSUE_PREFIX}_{entry.entry_id}"
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

Re-implements the fix for [#22](https://github.com/antbald/ha-ev-smart-charger/issues/22) (reported by @xion2000) on top of current `master` (**v2.1.0 → v2.1.1**), and **supersedes the stale [#25](https://github.com/antbald/ha-ev-smart-charger/pull/25)** (which was ~10 versions behind master, `CONFLICTING`/`DIRTY`, and whose only tester most likely mis-installed a branch download rather than a release).

**Bug**: disabling *any* helper entity in Home Assistant stopped the integration from initializing after a restart. HA skips `async_added_to_hass` for disabled entities ([entity_base.py:51](custom_components/ev_smart_charger/entity_base.py#L51)), so the Phase 1 registration counter never reached `expected_entity_count` (66 / 52 PV-only), the 10 s `asyncio.wait_for` timed out, and setup raised an opaque `ConfigEntryNotReady`.

## What changed

New `_async_wait_for_helper_registration()` in [`__init__.py`](custom_components/ev_smart_charger/__init__.py) replaces the inline `try/except`. On timeout it reconciles against the **entity registry** (`disabled_by != None`):

- **`registered + disabled >= expected`** → user consciously disabled them. Log a WARNING, surface a Home Assistant **Repairs** entry (`translation_key="disabled_helpers"`, severity WARNING, EN/IT/NL), proceed in degraded mode. `state_helper` already defaults safely on `None`/`unknown`/`unavailable`. The Repairs entry clears on the next clean boot.
- **real shortfall** → log an ERROR with the genuinely-missing count and raise `ConfigEntryNotReady` so HA retries.

The unique-id matcher (`_entity_key_from_unique_id`, format `{DOMAIN}_{entry_id}_{key}`) was **re-verified** against the real format at [entity_base.py:31](custom_components/ev_smart_charger/entity_base.py#L31).

A **coupling comment** was added next to `TOTAL_INTEGRATION_ENTITIES` in [const.py](custom_components/ev_smart_charger/const.py): the tolerance assumes the constant equals the number of entities created when nothing is disabled; if it drifts above reality (cf. the v1.6.20 regression), a single disabled entity would silently tip the count back into a hard `ConfigEntryNotReady`.

## Tests ([tests/test_integration_setup.py](tests/test_integration_setup.py))

- `test_entity_key_from_unique_id_matches_evsc_pattern` / `…_rejects_foreign_unique_id` — the extractor accepts valid EVSC unique_ids and rejects foreign + cross-entry ones.
- `test_async_setup_entry_proceeds_with_user_disabled_helpers` — mirrors @xion2000's setup: **7 real `entity_registry` entries with `RegistryEntryDisabler.USER`** (not mocked counts), registration barrier times out, asserts `async_setup_entry` returns `True` **and** a `disabled_helpers` Repairs issue exists with the right `count` placeholder.
- `test_async_setup_entry_raises_not_ready_on_real_shortfall` — genuine shortfall (nothing disabled, far too few registered) still raises `ConfigEntryNotReady` and creates **no** Repairs issue.

Local: `test_integration_setup.py` **9/9 pass**; full suite 138 passed / 19 failed where the 19 are the **pre-existing environment-only baseline** (verified identical on clean `master`). `ruff` clean, `py_compile` OK, JSON locale parity OK.

## Files

`__init__.py`, `const.py`, `manifest.json`, `strings.json`, `translations/{en,it,nl}.json`, `tests/test_integration_setup.py`, `CLAUDE.md`. `VERSION = "2.1.1"`.

## Backward compatibility

Zero schema / entity / config-flow changes. Installs with all helpers enabled hit the unchanged happy path. 🟢 RECOMMENDED for anyone who disabled helper entities; ⚪ NO-OP otherwise.

## Follow-up

Proper opt-out toggles per feature group (so users don't need to disable entities at all) remain tracked at [#24](https://github.com/antbald/ha-ev-smart-charger/issues/24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
